### PR TITLE
Add typed response serialization pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,4 +89,11 @@ jobs:
                   test "$invalid_status" = "400"
                   php -r '$body = json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR); exit($body["error"]["status"] === 400 ? 0 : 1);' /tmp/gustav-invalid.json
 
+                  typed_response=$(curl --fail --silent http://127.0.0.1:5173/responses/direct-dto)
+                  php -r '$body = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); exit($body["state"] === "active" && $body["owner"] === ["name" => "Ada"] && is_float($body["rating"]) && !array_key_exists("internalNote", $body) ? 0 : 1);' <<< "$typed_response"
+
+                  serialization_status=$(curl --silent --output /tmp/gustav-serialization-error.json --write-out '%{http_code}' \
+                      http://127.0.0.1:5173/responses/circular)
+                  test "$serialization_status" = "500"
+
                   test "$(curl --fail --silent http://127.0.0.1:5173/responses/plaintext)" = "lorem ipsum"

--- a/src/Application.php
+++ b/src/Application.php
@@ -6,7 +6,7 @@ use Composer\InstalledVersions;
 use Exception;
 use GustavPHP\Gustav\Controller\{ControllerFactory, Response};
 use GustavPHP\Gustav\Http\Binding\RequestBinder;
-use GustavPHP\Gustav\Http\CallableRequestHandler;
+use GustavPHP\Gustav\Http\{CallableRequestHandler, ResponseHandler};
 use GustavPHP\Gustav\Http\Exception\{HttpException, RequestInputException, ValidationException};
 use GustavPHP\Gustav\Middleware\Pipeline;
 use GustavPHP\Gustav\Router\{Method, Router};
@@ -49,6 +49,10 @@ class Application implements RequestHandlerInterface
      * @var array<int,RequestBinder>
      */
     protected array $requestBinders = [];
+    /**
+     * @var array<int,ResponseHandler>
+     */
+    protected array $responseHandlers = [];
 
     /**
      * Creates a new application instance.
@@ -229,21 +233,12 @@ class Application implements RequestHandlerInterface
             throw new LogicException('Request binder has not been initialized');
         }
         $payload = $instance->{$route->getFunction()}(...$requestBinder->bind($request, $route->getPlaceholders()));
-
-        if ($payload instanceof Controller\Response) {
-            $serializer = $payload->getSerializer();
-            if ($serializer) {
-                $payload->setBody(Serializer\Manager::getEntity($serializer::class)->serialize($serializer));
-                $payload->setBody(json_encode($payload->getBody()));
-            }
-
-            return $payload->build();
-        }
-        if ($payload instanceof ResponseInterface) {
-            return $payload;
+        $responseHandler = $this->responseHandlers[spl_object_id($route)] ?? null;
+        if ($responseHandler === null) {
+            throw new LogicException('Response handler has not been initialized');
         }
 
-        throw new LogicException('Controller needs to return a response object');
+        return $responseHandler->respond($payload);
     }
 
     /**
@@ -448,6 +443,10 @@ class Application implements RequestHandlerInterface
      */
     private function prepareRoute(ReflectionMethod $method, Attribute\Route $route): void
     {
-        $this->requestBinders[spl_object_id($route)] = RequestBinder::compile($method, $route->getPath());
+        $requestBinder = RequestBinder::compile($method, $route->getPath());
+        $responseHandler = ResponseHandler::compile($method);
+        $routeId = spl_object_id($route);
+        $this->requestBinders[$routeId] = $requestBinder;
+        $this->responseHandlers[$routeId] = $responseHandler;
     }
 }

--- a/src/Attribute/JsonResponse.php
+++ b/src/Attribute/JsonResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final readonly class JsonResponse
+{
+    /**
+     * @param array<string,string|array<string>> $headers
+     */
+    public function __construct(
+        public int $status = 200,
+        public array $headers = [],
+    ) {
+        if ($status < 100 || $status > 599) {
+            throw new InvalidArgumentException('JSON response status must be between 100 and 599');
+        }
+    }
+}

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -36,22 +36,21 @@ class Base
     /**
      * Returns a JSON Response.
      *
-     * @param array<mixed>|object $data
+     * @param mixed $data
      * @param int $status
      * @param array<string,string|array<string>> $headers
      * @return Response
      */
     protected function json(
-        array|object $data,
+        mixed $data,
         int $status = 200,
         array $headers = []
     ): Response {
         return new Response(
             status: $status,
-            body: json_encode($data),
-            headers: array_merge($headers, [
-                'Content-Type' => 'application/json',
-            ])
+            body: $data,
+            headers: $headers,
+            format: ResponseFormat::Json,
         );
     }
 
@@ -109,9 +108,8 @@ class Base
         return new Response(
             status: $status,
             body: $object,
-            headers: array_merge($headers, [
-                'Content-Type' => 'application/json',
-            ])
+            headers: $headers,
+            format: ResponseFormat::Json,
         );
     }
 

--- a/src/Controller/Response.php
+++ b/src/Controller/Response.php
@@ -3,7 +3,6 @@
 namespace GustavPHP\Gustav\Controller;
 
 use GustavPHP\Gustav\Serializer;
-use InvalidArgumentException;
 use Nyholm\Psr7\Response as Psr7Response;
 
 class Response
@@ -20,6 +19,7 @@ class Response
         protected int $status = 200,
         protected array $headers = [],
         protected mixed $body = '',
+        protected ResponseFormat $format = ResponseFormat::Raw,
     ) {
     }
     /**
@@ -29,14 +29,21 @@ class Response
      */
     public function build(): Psr7Response
     {
+        $headers = $this->headers;
+        $body = $this->body;
+        if ($this->format === ResponseFormat::Json) {
+            $headers = array_merge($headers, ['Content-Type' => 'application/json']);
+            $body = Serializer\Manager::encode($body);
+        }
+
         return new Psr7Response(
             $this->status,
-            $this->headers,
-            $this->body
+            $headers,
+            $body,
         );
     }
     /**
-     * Build a Response with a JSON body.
+     * Build a Response with an HTML body.
      *
      * @return Psr7Response
      */
@@ -52,14 +59,14 @@ class Response
      * Build a Response with a JSON body.
      *
      * @return Psr7Response
-     * @throws InvalidArgumentException
+     * @throws Serializer\SerializationException
      */
     public function buildJson(): Psr7Response
     {
         return new Psr7Response(
             $this->status,
             array_merge($this->headers, ['Content-Type' => 'application/json']),
-            (string) json_encode($this->body)
+            Serializer\Manager::encode($this->body),
         );
     }
     /**
@@ -126,6 +133,7 @@ class Response
         }
         if ($response->body) {
             $this->body = $response->body;
+            $this->format = $response->format;
         }
         $this->headers = array_merge($this->headers, $response->headers);
 

--- a/src/Controller/ResponseFormat.php
+++ b/src/Controller/ResponseFormat.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Gustav\Controller;
+
+enum ResponseFormat
+{
+    case Json;
+    case Raw;
+}

--- a/src/Http/ResponseHandler.php
+++ b/src/Http/ResponseHandler.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace GustavPHP\Gustav\Http;
+
+use BackedEnum;
+use GustavPHP\Gustav\Attribute\JsonResponse;
+use GustavPHP\Gustav\Controller\{Response, ResponseFormat};
+use GustavPHP\Gustav\Serializer\Manager;
+use JsonSerializable;
+use LogicException;
+use Psr\Http\Message\ResponseInterface;
+use ReflectionMethod;
+use ReflectionNamedType;
+use UnitEnum;
+
+final readonly class ResponseHandler
+{
+    private function __construct(private ?JsonResponse $jsonResponse)
+    {
+    }
+
+    public static function compile(ReflectionMethod $method): self
+    {
+        $location = "Controller method {$method->getDeclaringClass()->getName()}::{$method->getName()}()";
+        $type = $method->getReturnType();
+        if (!$type instanceof ReflectionNamedType) {
+            throw new LogicException("{$location} must declare one response type");
+        }
+
+        $attributes = $method->getAttributes(JsonResponse::class);
+        /** @var JsonResponse|null $jsonResponse */
+        $jsonResponse = $attributes === [] ? null : $attributes[0]->newInstance();
+
+        if ($jsonResponse === null) {
+            self::assertResponseObject($type, $location);
+        } else {
+            self::assertJsonType($type, $location);
+        }
+
+        return new self($jsonResponse);
+    }
+
+    public function respond(mixed $payload): ResponseInterface
+    {
+        if ($this->jsonResponse !== null) {
+            return (new Response(
+                status: $this->jsonResponse->status,
+                headers: $this->jsonResponse->headers,
+                body: $payload,
+                format: ResponseFormat::Json,
+            ))->build();
+        }
+
+        if ($payload instanceof Response) {
+            return $payload->build();
+        }
+        if ($payload instanceof ResponseInterface) {
+            return $payload;
+        }
+
+        throw new LogicException('Controller returned a value that does not match its compiled response type');
+    }
+
+    private static function assertJsonType(ReflectionNamedType $type, string $location): void
+    {
+        $name = $type->getName();
+        if ($type->isBuiltin()) {
+            if (!in_array($name, ['array', 'bool', 'false', 'float', 'int', 'null', 'string', 'true'], true)) {
+                throw new LogicException("{$location} declares an unsupported JsonResponse type {$name}");
+            }
+
+            return;
+        }
+
+        if (is_a($name, Response::class, true) || is_a($name, ResponseInterface::class, true)) {
+            throw new LogicException("{$location} cannot use JsonResponse with a response object return type");
+        }
+        if (is_a($name, UnitEnum::class, true) && !is_a($name, BackedEnum::class, true)) {
+            throw new LogicException("{$location} cannot serialize an unbacked enum");
+        }
+        if (is_a($name, BackedEnum::class, true) || is_a($name, JsonSerializable::class, true)) {
+            return;
+        }
+
+        /** @var class-string<object> $name */
+        Manager::prepare($name);
+    }
+
+    private static function assertResponseObject(ReflectionNamedType $type, string $location): void
+    {
+        if ($type->allowsNull()) {
+            throw new LogicException("{$location} must return a non-null response object");
+        }
+
+        $name = $type->getName();
+        if (
+            in_array($name, ['parent', 'self', 'static'], true)
+            || $type->isBuiltin()
+            || (!is_a($name, Response::class, true) && !is_a($name, ResponseInterface::class, true))
+        ) {
+            throw new LogicException("{$location} must return a response object or use JsonResponse");
+        }
+    }
+}

--- a/src/Serializer/Base.php
+++ b/src/Serializer/Base.php
@@ -2,6 +2,9 @@
 
 namespace GustavPHP\Gustav\Serializer;
 
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]
 class Base
 {
 }

--- a/src/Serializer/Entity.php
+++ b/src/Serializer/Entity.php
@@ -2,55 +2,21 @@
 
 namespace GustavPHP\Gustav\Serializer;
 
-use GustavPHP\Gustav\Attribute\Serializer\{AdditionalProperties, Exclude};
 use InvalidArgumentException;
-use ReflectionClass;
-use ReflectionException;
+use stdClass;
 
 class Entity
 {
     /**
-     * @var string
-     */
-    protected string $className;
-    /**
-     * @var array<string>
-     */
-    protected array $excluded = [];
-    /**
-     * @var bool
-     */
-    protected bool $hasAdditionalProperties = false;
-    /**
-     * @var array<string>
-     */
-    protected array $properties = [];
-    /**
-     * @var ReflectionClass
-     */
-    protected ReflectionClass $reflection;
-
-    /**
      * @param class-string<Base> $className
-     * @return void
-     * @throws ReflectionException
      */
     public function __construct(
-        string $className
+        protected string $className
     ) {
         if (!is_subclass_of($className, Base::class)) {
             throw new InvalidArgumentException("Class {$className} is not a subclass of " . Base::class);
         }
-        $this->reflection = new ReflectionClass($className);
-        $this->hasAdditionalProperties = !!$this->reflection->getAttributes(AdditionalProperties::class);
-        foreach ($this->reflection->getProperties() as $property) {
-            $excluded = !!$property->getAttributes(Exclude::class);
-            if ($excluded) {
-                $this->excluded[] = $property->getName();
-            } else {
-                $this->properties[] = $property->getName();
-            }
-        }
+        Manager::prepare($className);
     }
 
     /**
@@ -59,25 +25,38 @@ class Entity
      */
     public function serialize(Base $instance): array
     {
-        $data = get_object_vars($instance);
-        foreach ($this->excluded as $key) {
-            if (array_key_exists($key, $data)) {
-                unset($data[$key]);
-            }
+        if (!$instance instanceof $this->className) {
+            throw new InvalidArgumentException("Serializer instance must be an instance of {$this->className}");
         }
-        if (!$this->hasAdditionalProperties) {
-            foreach (array_keys($data) as $key) {
-                if (!in_array($key, $this->properties)) {
-                    unset($data[$key]);
-                }
-            }
+
+        $normalized = Manager::normalize($instance);
+        if (!$normalized instanceof stdClass) {
+            throw new SerializationException("Serializer {$this->className} did not normalize to an object");
         }
-        foreach ($data as $key => $value) {
-            if ($value instanceof Base) {
-                $data[$key] = Manager::getEntity($value::class)->serialize($value);
-            } elseif (is_array($value)) {
-                $data[$key] = array_map(fn ($p) => Manager::getEntity($p::class)->serialize($p), array_filter($value, fn ($p) => $p instanceof Base));
-            }
+
+        return self::objectToArray($normalized);
+    }
+
+    private static function normalizedToArray(mixed $value): mixed
+    {
+        if ($value instanceof stdClass) {
+            return self::objectToArray($value);
+        }
+        if (is_array($value)) {
+            return array_map(self::normalizedToArray(...), $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private static function objectToArray(stdClass $object): array
+    {
+        $data = [];
+        foreach (get_object_vars($object) as $key => $value) {
+            $data[$key] = self::normalizedToArray($value);
         }
 
         return $data;

--- a/src/Serializer/Manager.php
+++ b/src/Serializer/Manager.php
@@ -2,6 +2,7 @@
 
 namespace GustavPHP\Gustav\Serializer;
 
+use JsonException;
 use ReflectionException;
 
 class Manager
@@ -10,6 +11,9 @@ class Manager
      * @var array<class-string<Base>,Entity>
      */
     protected static array $entities = [];
+
+    /** @var array<class-string<object>,ObjectMetadata> */
+    protected static array $metadata = [];
     /**
      *
      * @param class-string<Base> $className
@@ -20,9 +24,48 @@ class Manager
     {
         self::$entities[$className] = new Entity($className);
     }
+
+    /**
+     * Encode a value using Gustav's deterministic JSON representation.
+     */
+    public static function encode(mixed $value): string
+    {
+        try {
+            return json_encode(
+                self::normalize($value),
+                JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PRESERVE_ZERO_FRACTION,
+            );
+        } catch (JsonException $exception) {
+            throw new SerializationException('Unable to encode normalized JSON data', previous: $exception);
+        }
+    }
+
     public static function getEntity(string $className): Entity
     {
         return self::$entities[$className];
+    }
+
+    /**
+     * @param class-string<object> $className
+     */
+    public static function metadata(string $className): ObjectMetadata
+    {
+        return self::$metadata[$className] ??= new ObjectMetadata($className);
+    }
+
+    public static function normalize(mixed $value): mixed
+    {
+        return (new Normalizer())->normalize($value);
+    }
+
+    /**
+     * Compile serialization metadata before a route receives traffic.
+     *
+     * @param class-string<object> $className
+     */
+    public static function prepare(string $className): void
+    {
+        self::metadata($className);
     }
 
     /**
@@ -31,5 +74,6 @@ class Manager
     public static function reset(): void
     {
         self::$entities = [];
+        self::$metadata = [];
     }
 }

--- a/src/Serializer/Normalizer.php
+++ b/src/Serializer/Normalizer.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace GustavPHP\Gustav\Serializer;
+
+use BackedEnum;
+use Closure;
+use JsonSerializable;
+use SplObjectStorage;
+use UnitEnum;
+
+final class Normalizer
+{
+    private const MAX_DEPTH = 64;
+
+    /** @var SplObjectStorage<object,null> */
+    private SplObjectStorage $activeObjects;
+
+    public function __construct()
+    {
+        $this->activeObjects = new SplObjectStorage();
+    }
+
+    public function normalize(mixed $value, string $path = '$', int $depth = 0): mixed
+    {
+        if ($depth > self::MAX_DEPTH) {
+            throw new SerializationException("Maximum JSON serialization depth exceeded at {$path}");
+        }
+        if ($value === null || is_string($value) || is_int($value) || is_bool($value)) {
+            return $value;
+        }
+        if (is_float($value)) {
+            if (!is_finite($value)) {
+                throw new SerializationException("Non-finite float cannot be serialized at {$path}");
+            }
+
+            return $value;
+        }
+        if (is_array($value)) {
+            $normalized = [];
+            foreach ($value as $key => $item) {
+                $normalized[$key] = $this->normalize($item, self::arrayPath($path, $key), $depth + 1);
+            }
+
+            return $normalized;
+        }
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+        if ($value instanceof UnitEnum) {
+            throw new SerializationException('Unbacked enum ' . $value::class . " cannot be serialized at {$path}");
+        }
+        if ($value instanceof Closure || is_resource($value)) {
+            throw new SerializationException('Unsupported value of type ' . get_debug_type($value) . " at {$path}");
+        }
+        if (!is_object($value)) {
+            throw new SerializationException('Unsupported value of type ' . get_debug_type($value) . " at {$path}");
+        }
+        if ($this->activeObjects->offsetExists($value)) {
+            throw new SerializationException("Circular object reference detected at {$path}");
+        }
+
+        $this->activeObjects->offsetSet($value);
+        try {
+            if ($value instanceof JsonSerializable) {
+                return $this->normalize($value->jsonSerialize(), $path, $depth + 1);
+            }
+
+            return Manager::metadata($value::class)->normalize(
+                $value,
+                fn (mixed $item, string $itemPath): mixed => $this->normalize($item, $itemPath, $depth + 1),
+                $path,
+            );
+        } finally {
+            $this->activeObjects->offsetUnset($value);
+        }
+    }
+
+    private static function arrayPath(string $path, int|string $key): string
+    {
+        if (is_int($key)) {
+            return "{$path}[{$key}]";
+        }
+
+        return preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $key) === 1
+            ? "{$path}.{$key}"
+            : $path . '[' . json_encode($key, JSON_THROW_ON_ERROR) . ']';
+    }
+}

--- a/src/Serializer/ObjectMetadata.php
+++ b/src/Serializer/ObjectMetadata.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace GustavPHP\Gustav\Serializer;
+
+use GustavPHP\Gustav\Attribute\Serializer\{AdditionalProperties, Exclude};
+use ReflectionClass;
+use ReflectionProperty;
+use stdClass;
+
+final readonly class ObjectMetadata
+{
+    private bool $additionalProperties;
+
+    /** @var array<string,true> */
+    private array $excluded;
+    /** @var list<ReflectionProperty> */
+    private array $properties;
+
+    /**
+     * @param class-string<object> $className
+     */
+    public function __construct(private string $className)
+    {
+        $reflection = new ReflectionClass($className);
+        if ($reflection->isInternal() && $className !== stdClass::class) {
+            throw new SerializationException("Internal class {$className} does not define a supported JSON representation");
+        }
+        if ($reflection->isInterface() || $reflection->isTrait() || $reflection->isEnum()) {
+            throw new SerializationException("{$className} is not a serializable DTO class");
+        }
+
+        $properties = [];
+        $excluded = [];
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+            if ($property->getAttributes(Exclude::class) !== []) {
+                $excluded[$property->getName()] = true;
+
+                continue;
+            }
+            $properties[] = $property;
+        }
+
+        $this->properties = $properties;
+        $this->excluded = $excluded;
+        $this->additionalProperties = $className === stdClass::class
+            || $reflection->getAttributes(AdditionalProperties::class) !== [];
+    }
+
+    /**
+     * @param callable(mixed,string): mixed $normalize
+     */
+    public function normalize(object $object, callable $normalize, string $path): stdClass
+    {
+        $data = new stdClass();
+        $declared = [];
+        foreach ($this->properties as $property) {
+            $name = $property->getName();
+            $declared[$name] = true;
+            if (!$property->isInitialized($object)) {
+                throw new SerializationException("Property {$this->className}::\${$name} is not initialized at {$path}");
+            }
+            $data->{$name} = $normalize($property->getValue($object), self::childPath($path, $name));
+        }
+
+        if ($this->additionalProperties) {
+            foreach (get_object_vars($object) as $name => $value) {
+                if (isset($declared[$name]) || isset($this->excluded[$name])) {
+                    continue;
+                }
+                $data->{$name} = $normalize($value, self::childPath($path, $name));
+            }
+        }
+
+        return $data;
+    }
+
+    private static function childPath(string $path, string $name): string
+    {
+        return preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) === 1
+            ? "{$path}.{$name}"
+            : $path . '[' . json_encode($name, JSON_THROW_ON_ERROR) . ']';
+    }
+}

--- a/src/Serializer/SerializationException.php
+++ b/src/Serializer/SerializationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Gustav\Serializer;
+
+use RuntimeException;
+
+final class SerializationException extends RuntimeException
+{
+}

--- a/tests/Fixtures/AmbiguousResponseController.php
+++ b/tests/Fixtures/AmbiguousResponseController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures;
+
+use GustavPHP\Gustav\Attribute\Route;
+use GustavPHP\Gustav\Controller;
+use Psr\Http\Message\ResponseInterface;
+
+final class AmbiguousResponseController extends Controller\Base
+{
+    #[Route('/invalid-response/union')]
+    public function invalid(): Controller\Response|ResponseInterface
+    {
+        return $this->json([]);
+    }
+}

--- a/tests/Fixtures/InvalidJsonResponseController.php
+++ b/tests/Fixtures/InvalidJsonResponseController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures;
+
+use GustavPHP\Gustav\Attribute\{JsonResponse, Route};
+use GustavPHP\Gustav\Controller;
+
+final class InvalidJsonResponseController extends Controller\Base
+{
+    #[Route('/invalid-response/json')]
+    #[JsonResponse]
+    public function invalid(): Controller\Response
+    {
+        return $this->json([]);
+    }
+}

--- a/tests/Fixtures/InvalidJsonStatusController.php
+++ b/tests/Fixtures/InvalidJsonStatusController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures;
+
+use GustavPHP\Gustav\Attribute\{JsonResponse, Route};
+use GustavPHP\Gustav\Controller;
+
+final class InvalidJsonStatusController extends Controller\Base
+{
+    #[Route('/invalid-response/status')]
+    #[JsonResponse(status: 99)]
+    public function invalid(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/NullableResponseController.php
+++ b/tests/Fixtures/NullableResponseController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures;
+
+use GustavPHP\Gustav\Attribute\Route;
+use GustavPHP\Gustav\Controller;
+
+final class NullableResponseController extends Controller\Base
+{
+    #[Route('/invalid-response/nullable')]
+    public function invalid(): ?Controller\Response
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/UnbackedResponseState.php
+++ b/tests/Fixtures/UnbackedResponseState.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures;
+
+enum UnbackedResponseState
+{
+    case Ready;
+}

--- a/tests/Fixtures/UntypedResponseController.php
+++ b/tests/Fixtures/UntypedResponseController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures;
+
+use GustavPHP\Gustav\Attribute\Route;
+use GustavPHP\Gustav\Controller;
+
+final class UntypedResponseController extends Controller\Base
+{
+    #[Route('/invalid-response/untyped')]
+    public function invalid()
+    {
+        return $this->json([]);
+    }
+}

--- a/tests/Integration/DTO/CircularOutput.php
+++ b/tests/Integration/DTO/CircularOutput.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\DTO;
+
+final class CircularOutput
+{
+    public ?self $next = null;
+
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/tests/Integration/DTO/DogOutput.php
+++ b/tests/Integration/DTO/DogOutput.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\DTO;
+
+use GustavPHP\Gustav\Attribute\Serializer\Exclude;
+
+final readonly class DogOutput
+{
+    /**
+     * @param list<OwnerOutput> $watchers
+     * @param list<string|int|bool> $labels
+     */
+    public function __construct(
+        public int $id,
+        public string $name,
+        public ResponseState $state,
+        public ?string $nickname,
+        public OwnerOutput $owner,
+        public array $watchers,
+        public array $labels,
+        public float $rating,
+        #[Exclude]
+        public string $internalNote,
+    ) {
+    }
+}

--- a/tests/Integration/DTO/OwnerOutput.php
+++ b/tests/Integration/DTO/OwnerOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\DTO;
+
+use GustavPHP\Gustav\Attribute\Serializer\Exclude;
+
+final readonly class OwnerOutput
+{
+    public function __construct(
+        public string $name,
+        #[Exclude]
+        public string $token,
+    ) {
+    }
+}

--- a/tests/Integration/DTO/ResponseState.php
+++ b/tests/Integration/DTO/ResponseState.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\DTO;
+
+enum ResponseState: string
+{
+    case Active = 'active';
+    case Archived = 'archived';
+}

--- a/tests/Integration/DTO/UninitializedOutput.php
+++ b/tests/Integration/DTO/UninitializedOutput.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\DTO;
+
+final class UninitializedOutput
+{
+    public string $name;
+}

--- a/tests/Integration/DTO/UnsupportedOutput.php
+++ b/tests/Integration/DTO/UnsupportedOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\DTO;
+
+use Closure;
+
+final readonly class UnsupportedOutput
+{
+    public Closure $callback;
+
+    public function __construct()
+    {
+        $this->callback = static fn (): string => 'not serializable';
+    }
+}

--- a/tests/Integration/Routes/Responses.php
+++ b/tests/Integration/Routes/Responses.php
@@ -2,11 +2,62 @@
 
 namespace GustavPHP\Tests\Integration\Routes;
 
-use GustavPHP\Gustav\Attribute\Route;
+use GustavPHP\Gustav\Attribute\{JsonResponse, Route};
 use GustavPHP\Gustav\Controller;
+use GustavPHP\Tests\Integration\DTO\{CircularOutput, DogOutput, OwnerOutput, ResponseState, UninitializedOutput, UnsupportedOutput};
+use GustavPHP\Tests\Integration\Serializers\LegacyOutput;
 
 class Responses extends Controller\Base
 {
+    #[Route('/responses/circular')]
+    public function circular(): Controller\Response
+    {
+        $output = new CircularOutput('root');
+        $output->next = $output;
+
+        return $this->json($output);
+    }
+
+    #[Route('/responses/direct-collection')]
+    #[JsonResponse(status: 201, headers: ['X-Response-Mode' => 'compiled'])]
+    public function directCollection(): array
+    {
+        return [
+            'dogs' => [$this->dog(1), $this->dog(2)],
+            'state' => ResponseState::Active,
+            'empty' => null,
+        ];
+    }
+
+    #[Route('/responses/direct-dto')]
+    #[JsonResponse]
+    public function directDto(): DogOutput
+    {
+        return $this->dog(1);
+    }
+
+    #[Route('/responses/direct-null')]
+    #[JsonResponse]
+    public function directNull(): ?DogOutput
+    {
+        return null;
+    }
+
+    #[Route('/responses/dto-helper')]
+    public function dtoHelper(): Controller\Response
+    {
+        return $this->json($this->dog(1));
+    }
+
+    #[Route('/responses/legacy-serializer')]
+    public function legacySerializer(): Controller\Response
+    {
+        $output = new LegacyOutput();
+        $output->extra = 'included';
+
+        return $this->serialize($output);
+    }
+
     #[Route('/responses/html')]
     public function returnHtml(): Controller\Response
     {
@@ -52,5 +103,36 @@ class Responses extends Controller\Base
     public function returnXml(): Controller\Response
     {
         return $this->xml('<root><lorem>ipsum</lorem></root>');
+    }
+
+    #[Route('/responses/uninitialized')]
+    #[JsonResponse]
+    public function uninitialized(): UninitializedOutput
+    {
+        return new UninitializedOutput();
+    }
+
+    #[Route('/responses/unsupported')]
+    public function unsupported(): Controller\Response
+    {
+        return $this->json(new UnsupportedOutput());
+    }
+
+    private function dog(int $id): DogOutput
+    {
+        return new DogOutput(
+            id: $id,
+            name: "Dog {$id}",
+            state: ResponseState::Active,
+            nickname: null,
+            owner: new OwnerOutput('Ada', 'owner-secret'),
+            watchers: [
+                new OwnerOutput('Grace', 'watcher-secret'),
+                new OwnerOutput('Linus', 'watcher-secret'),
+            ],
+            labels: ['friendly', 0, false],
+            rating: 1.0,
+            internalNote: 'do not expose',
+        );
     }
 }

--- a/tests/Integration/Routes/Responses.php
+++ b/tests/Integration/Routes/Responses.php
@@ -36,6 +36,20 @@ class Responses extends Controller\Base
         return $this->dog(1);
     }
 
+    #[Route('/responses/direct-enum')]
+    #[JsonResponse]
+    public function directEnum(): ResponseState
+    {
+        return ResponseState::Active;
+    }
+
+    #[Route('/responses/direct-false')]
+    #[JsonResponse]
+    public function directFalse(): bool
+    {
+        return false;
+    }
+
     #[Route('/responses/direct-null')]
     #[JsonResponse]
     public function directNull(): ?DogOutput

--- a/tests/Integration/Serializers/LegacyChild.php
+++ b/tests/Integration/Serializers/LegacyChild.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Serializers;
+
+use GustavPHP\Gustav\Serializer;
+
+final class LegacyChild extends Serializer\Base
+{
+    public string $name = 'child';
+}

--- a/tests/Integration/Serializers/LegacyOutput.php
+++ b/tests/Integration/Serializers/LegacyOutput.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Serializers;
+
+use AllowDynamicProperties;
+use GustavPHP\Gustav\Attribute\Serializer\{AdditionalProperties, Exclude};
+use GustavPHP\Gustav\Serializer;
+
+#[AllowDynamicProperties]
+#[AdditionalProperties]
+final class LegacyOutput extends Serializer\Base
+{
+    /** @var list<LegacyChild|string|int> */
+    public array $items;
+    public string $name = 'legacy';
+    #[Exclude]
+    public string $secret = 'internal';
+
+    public function __construct()
+    {
+        $this->items = [new LegacyChild(), 'kept', 0];
+    }
+}

--- a/tests/Integration/Tests/ParamsTest.php
+++ b/tests/Integration/Tests/ParamsTest.php
@@ -252,7 +252,7 @@ describe('request input binding', function () use ($client) {
         expect($response->getStatusCode())->toBe(200)
             ->and(json_decode((string) $response->getBody(), true))->toBe([
                 'email' => 'ada@example.com',
-                'score' => -2,
+                'score' => -2.0,
             ]);
     });
 

--- a/tests/Integration/Tests/ResponsesTest.php
+++ b/tests/Integration/Tests/ResponsesTest.php
@@ -90,6 +90,15 @@ describe('response', function () use ($client) {
             ->and((string) $response->getBody())->toBe('null');
     });
 
+    it('serializes direct scalar and backed enum responses', function () use ($client) {
+        $boolean = $client->request('GET', '/responses/direct-false');
+        $enum = $client->request('GET', '/responses/direct-enum');
+
+        expect($boolean->getStatusCode())->toBe(200)
+            ->and((string) $boolean->getBody())->toBe('false')
+            ->and((string) $enum->getBody())->toBe('"active"');
+    });
+
     it('uses the same normalizer through the JSON helper', function () use ($client) {
         $response = $client->request('GET', '/responses/dto-helper');
         $body = json_decode((string) $response->getBody(), true);

--- a/tests/Integration/Tests/ResponsesTest.php
+++ b/tests/Integration/Tests/ResponsesTest.php
@@ -46,4 +46,104 @@ describe('response', function () use ($client) {
         expect($response->getHeaderLine('Location'))->toBe('/responses/plaintext');
         expect($response->getStatusCode())->toBe(301);
     });
+
+    it('serializes a directly returned readonly DTO recursively', function () use ($client) {
+        $response = $client->request('GET', '/responses/direct-dto');
+        $body = json_decode((string) $response->getBody(), true);
+
+        expect($response->getStatusCode())->toBe(200)
+            ->and($response->getHeaderLine('Content-Type'))->toBe('application/json')
+            ->and($body)->toBe([
+                'id' => 1,
+                'name' => 'Dog 1',
+                'state' => 'active',
+                'nickname' => null,
+                'owner' => ['name' => 'Ada'],
+                'watchers' => [
+                    ['name' => 'Grace'],
+                    ['name' => 'Linus'],
+                ],
+                'labels' => ['friendly', 0, false],
+                'rating' => 1.0,
+            ])
+            ->and((string) $response->getBody())->toContain('"rating":1.0')
+            ->not->toContain('secret')
+            ->not->toContain('internalNote');
+    });
+
+    it('applies direct JSON status and headers to recursive collections', function () use ($client) {
+        $response = $client->request('GET', '/responses/direct-collection');
+        $body = json_decode((string) $response->getBody(), true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($response->getHeaderLine('X-Response-Mode'))->toBe('compiled')
+            ->and($body['state'])->toBe('active')
+            ->and($body['dogs'])->toHaveCount(2)
+            ->and($body['dogs'][1]['name'])->toBe('Dog 2');
+    });
+
+    it('serializes a nullable direct response as JSON null', function () use ($client) {
+        $response = $client->request('GET', '/responses/direct-null');
+
+        expect($response->getStatusCode())->toBe(200)
+            ->and($response->getHeaderLine('Content-Type'))->toBe('application/json')
+            ->and((string) $response->getBody())->toBe('null');
+    });
+
+    it('uses the same normalizer through the JSON helper', function () use ($client) {
+        $response = $client->request('GET', '/responses/dto-helper');
+        $body = json_decode((string) $response->getBody(), true);
+
+        expect($response->getStatusCode())->toBe(200)
+            ->and($body['owner'])->toBe(['name' => 'Ada'])
+            ->and($body['watchers'])->toHaveCount(2)
+            ->and((string) $response->getBody())->not->toContain('secret');
+    });
+
+    it('preserves legacy serializers, mixed arrays, exclusions, and additional properties', function () use ($client) {
+        $response = $client->request('GET', '/responses/legacy-serializer');
+        $body = json_decode((string) $response->getBody(), true);
+
+        expect($response->getStatusCode())->toBe(200)
+            ->and($body)->toBe([
+                'items' => [
+                    ['name' => 'child'],
+                    'kept',
+                    0,
+                ],
+                'name' => 'legacy',
+                'extra' => 'included',
+            ]);
+    });
+
+    it('maps unsupported values, uninitialized fields, and cycles to safe production errors', function (
+        string $uri,
+    ) use ($client) {
+        $response = $client->request('GET', $uri);
+        $body = json_decode((string) $response->getBody(), true);
+
+        expect($response->getStatusCode())->toBe(500)
+            ->and($body)->toBe([
+                'error' => [
+                    'status' => 500,
+                    'message' => 'Server Error',
+                ],
+            ])
+            ->and((string) $response->getBody())->not->toContain('Closure')
+            ->not->toContain('CircularOutput')
+            ->not->toContain('UninitializedOutput');
+    })->with([
+        'unsupported value' => ['/responses/unsupported'],
+        'uninitialized field' => ['/responses/uninitialized'],
+        'circular reference' => ['/responses/circular'],
+    ]);
+
+    it('continues serving after response serialization fails', function () use ($client) {
+        $failed = $client->request('GET', '/responses/circular');
+        $next = $client->request('GET', '/responses/plaintext');
+
+        expect($failed->getStatusCode())->toBe(500)
+            ->and($next->getStatusCode())->toBe(200)
+            ->and((string) $next->getBody())->toBe('lorem ipsum');
+    });
 });

--- a/tests/Unit/Http/ResponseHandlerTest.php
+++ b/tests/Unit/Http/ResponseHandlerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Tests\Fixtures\{AmbiguousResponseController, InvalidJsonResponseController, InvalidJsonStatusController, UntypedResponseController};
+
+it('requires route handlers to declare one response type', function (string $controller, string $message) {
+    responseApplication()->addRoutes([$controller]);
+})->with([
+    'missing return type' => [UntypedResponseController::class, 'must declare one response type'],
+    'ambiguous return union' => [AmbiguousResponseController::class, 'must declare one response type'],
+    'response object marked as direct JSON' => [InvalidJsonResponseController::class, 'cannot use JsonResponse'],
+])->throws(LogicException::class);
+
+it('rejects invalid direct JSON response statuses', function () {
+    responseApplication()->addRoutes([InvalidJsonStatusController::class]);
+})->throws(InvalidArgumentException::class, 'between 100 and 599');
+
+function responseApplication(): Application
+{
+    return new Application(new Configuration(
+        mode: Mode::Production,
+        namespace: 'GustavPHP\\Tests\\Empty',
+        cache: sys_get_temp_dir(),
+    ));
+}

--- a/tests/Unit/Http/ResponseHandlerTest.php
+++ b/tests/Unit/Http/ResponseHandlerTest.php
@@ -1,15 +1,17 @@
 <?php
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
-use GustavPHP\Tests\Fixtures\{AmbiguousResponseController, InvalidJsonResponseController, InvalidJsonStatusController, UntypedResponseController};
+use GustavPHP\Tests\Fixtures\{AmbiguousResponseController, InvalidJsonResponseController, InvalidJsonStatusController, NullableResponseController, UntypedResponseController};
 
 it('requires route handlers to declare one response type', function (string $controller, string $message) {
-    responseApplication()->addRoutes([$controller]);
+    expect(fn () => responseApplication()->addRoutes([$controller]))
+        ->toThrow(LogicException::class, $message);
 })->with([
     'missing return type' => [UntypedResponseController::class, 'must declare one response type'],
     'ambiguous return union' => [AmbiguousResponseController::class, 'must declare one response type'],
+    'nullable response object' => [NullableResponseController::class, 'must return a non-null response object'],
     'response object marked as direct JSON' => [InvalidJsonResponseController::class, 'cannot use JsonResponse'],
-])->throws(LogicException::class);
+]);
 
 it('rejects invalid direct JSON response statuses', function () {
     responseApplication()->addRoutes([InvalidJsonStatusController::class]);

--- a/tests/Unit/Serializer/ManagerTest.php
+++ b/tests/Unit/Serializer/ManagerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use GustavPHP\Gustav\Attribute\Serializer\Exclude;
+use GustavPHP\Gustav\Serializer\{Manager, SerializationException};
+use GustavPHP\Tests\Fixtures\UnbackedResponseState;
+
+it('normalizes DTOs, mixed collections, and float precision', function () {
+    $dto = new class ('Ada', 'secret') {
+        public function __construct(
+            public readonly string $name,
+            #[Exclude]
+            public readonly string $secret,
+        ) {
+        }
+    };
+
+    expect(Manager::encode([
+        'dto' => $dto,
+        'values' => ['kept', 0, false, null],
+        'decimal' => 1.0,
+    ]))->toBe('{"dto":{"name":"Ada"},"values":["kept",0,false,null],"decimal":1.0}');
+});
+
+it('preserves JSON object shape for empty DTOs', function () {
+    expect(Manager::encode(new class () {}))->toBe('{}');
+});
+
+it('honors JsonSerializable and recursively normalizes its result', function () {
+    $value = new class () implements JsonSerializable {
+        public function jsonSerialize(): mixed
+        {
+            return ['nested' => new class ('value') {
+                public function __construct(public readonly string $name)
+                {
+                }
+            }];
+        }
+    };
+
+    expect(Manager::encode($value))->toBe('{"nested":{"name":"value"}}');
+});
+
+it('substitutes invalid UTF-8 instead of emitting an invalid response', function () {
+    expect(Manager::encode(['invalid' => "\xB1"]))->toBe('{"invalid":"\\ufffd"}');
+});
+
+it('rejects closures', function () {
+    Manager::encode(fn (): null => null);
+})->throws(SerializationException::class);
+
+it('rejects unsupported JSON values', function (mixed $value) {
+    Manager::encode($value);
+})->with([
+    'non-finite float' => [INF],
+    'unbacked enum' => [UnbackedResponseState::Ready],
+])->throws(SerializationException::class);
+
+it('rejects self-referencing arrays at the serialization depth limit', function () {
+    $value = [];
+    $value['self'] = &$value;
+
+    Manager::encode($value);
+})->throws(SerializationException::class, 'Maximum JSON serialization depth exceeded');


### PR DESCRIPTION
## Summary

- add an explicit `#[JsonResponse]` contract for typed DTO, array, scalar, enum, and nullable controller returns
- compile and validate response metadata beside request binding metadata during route registration
- recursively normalize readonly DTOs, nested objects, mixed collections, backed enums, `JsonSerializable`, and `stdClass`
- share the same deterministic JSON pipeline across direct returns, `json()`, and the legacy `serialize()` facade
- detect unsupported values, uninitialized properties, excessive depth, and circular references without leaking production internals or stopping the worker

## Design decisions

- Direct JSON is explicit. Methods without `#[JsonResponse]` must return a non-null Gustav response or PSR-7 `ResponseInterface`; Gustav does not guess whether an arbitrary object return is JSON.
- Route registration rejects missing or ambiguous return types, nullable response objects, response objects marked as direct JSON, unsupported JSON types, and invalid status codes.
- Plain constructor-promoted readonly classes are the canonical output DTO. Initialized public properties are serialized, `#[Exclude]` removes sensitive fields, and dynamic fields require the existing `#[AdditionalProperties]` opt-in.
- Backed enums serialize to their backing value, finite floats preserve their PHP float shape (`1.0` stays `1.0`), and invalid UTF-8 is safely substituted.
- Serializer reflection metadata is cached by class. Direct DTO root metadata is prepared during route registration; nested runtime types are reflected at most once.
- Serialization failures are unexpected server failures, not validation errors. Production receives the existing safe `500` envelope while development retains the debug response.
- The existing `serialize(Serializer\Base)` API and direct PSR-7 responses remain supported; mixed scalar/object arrays no longer lose scalar members.

## Verification

- `composer format` — passed
- `composer dump-autoload --optimize --strict-psr` — passed (4,801 classes)
- `composer test` — passed (122 tests, 341 assertions)
- `composer check` — passed
- `composer lint` — passed
- `composer audit --format=plain` — no security advisories
- `composer validate --strict --no-check-publish` — passed
- `git diff --check` — passed
- live RoadRunner smoke — typed DTO `200`, malformed JSON `400`, circular output `500`, follow-up request `200`

Documentation: https://github.com/gustav-php/gustav-php.github.io/pull/3
