### PR TITLE
Declarative application services and injectable middleware

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,14 @@ jobs:
                   auth_status=$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:5173/kernel/auth)
                   test "$auth_status" = "401"
 
+                  service_json=$(curl --fail --silent http://127.0.0.1:5173/services/lifecycle)
+                  php -r '$body = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); exit($body["greeting"] === "configured" && $body["request"] === $body["middleware"] && $body["transientsDiffer"] === true ? 0 : 1);' <<< "$service_json"
+
+                  service_error_status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+                      http://127.0.0.1:5173/services/lifecycle/error)
+                  test "$service_error_status" = "418"
+                  curl --fail --silent --output /dev/null http://127.0.0.1:5173/services/lifecycle
+
                   valid_json=$(curl --fail --silent \
                       --header 'Content-Type: application/json' \
                       --data '{"email":"ada@example.com","age":"0","active":"false","status":"published","nickname":null}' \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,56 +52,24 @@ jobs:
             - name: Run linter
               run: composer run lint
 
-            - name: Setup RoadRunner
-              run: ./vendor/bin/rr get-binary --no-config
-
             - name: Run test suite
               run: composer run test
 
-            - name: Run RoadRunner transport smoke test
-              run: |
-                  ./rr serve -c .rr.yaml > /tmp/gustav-roadrunner.log 2>&1 &
-                  server_pid=$!
-                  trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+    transport:
+        name: RoadRunner boundary
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
 
-                  response=""
-                  for attempt in {1..20}; do
-                      if response=$(curl --fail --silent http://127.0.0.1:5173/responses/plaintext); then
-                          break
-                      fi
-                      sleep 0.25
-                  done
+        steps:
+            - uses: actions/checkout@v4
 
-                  test "$response" = "lorem ipsum"
-                  auth_status=$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:5173/kernel/auth)
-                  test "$auth_status" = "401"
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.2"
 
-                  service_json=$(curl --fail --silent http://127.0.0.1:5173/services/lifecycle)
-                  php -r '$body = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); exit($body["greeting"] === "configured" && $body["request"] === $body["middleware"] && $body["transientsDiffer"] === true ? 0 : 1);' <<< "$service_json"
+            - name: Install dependencies
+              run: composer install --prefer-dist --no-progress
 
-                  service_error_status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
-                      http://127.0.0.1:5173/services/lifecycle/error)
-                  test "$service_error_status" = "418"
-                  curl --fail --silent --output /dev/null http://127.0.0.1:5173/services/lifecycle
-
-                  valid_json=$(curl --fail --silent \
-                      --header 'Content-Type: application/json' \
-                      --data '{"email":"ada@example.com","age":"0","active":"false","status":"published","nickname":null}' \
-                      http://127.0.0.1:5173/params/body-dto)
-                  php -r '$body = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); exit($body["age"] === 0 && $body["active"] === false ? 0 : 1);' <<< "$valid_json"
-
-                  invalid_status=$(curl --silent --output /tmp/gustav-invalid.json --write-out '%{http_code}' \
-                      --header 'Content-Type: application/json' \
-                      --data '{"email":' \
-                      http://127.0.0.1:5173/params/body-dto)
-                  test "$invalid_status" = "400"
-                  php -r '$body = json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR); exit($body["error"]["status"] === 400 ? 0 : 1);' /tmp/gustav-invalid.json
-
-                  typed_response=$(curl --fail --silent http://127.0.0.1:5173/responses/direct-dto)
-                  php -r '$body = json_decode(stream_get_contents(STDIN), true, 512, JSON_THROW_ON_ERROR); exit($body["state"] === "active" && $body["owner"] === ["name" => "Ada"] && is_float($body["rating"]) && !array_key_exists("internalNote", $body) ? 0 : 1);' <<< "$typed_response"
-
-                  serialization_status=$(curl --silent --output /tmp/gustav-serialization-error.json --write-out '%{http_code}' \
-                      http://127.0.0.1:5173/responses/circular)
-                  test "$serialization_status" = "500"
-
-                  test "$(curl --fail --silent http://127.0.0.1:5173/responses/plaintext)" = "lorem ipsum"
+            - name: Run transport contract
+              run: composer test:transport

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 .pid
 .vscode/
 rr
+rr.exe
 test.log
 .DS_Store

--- a/.rr.yaml
+++ b/.rr.yaml
@@ -8,4 +8,4 @@ http:
   address: "0.0.0.0:5173"
   pool:
     debug: false
-    num_workers: 2
+    num_workers: 1

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ After the project has been created, start GustavPHP's local development server u
 php gustav dev
 ```
 
+## Development
+
+Run the fast in-process test suite with:
+
+```bash
+composer test
+```
+
+Run the focused RoadRunner boundary contract locally with:
+
+```bash
+composer test:transport
+```
+
+The transport command downloads the ignored local RoadRunner binary when it is
+missing, selects free ports, starts and stops the worker automatically, and
+prints its logs if the contract fails.
+
 ## Documentation
 
 - https://gustav-php.github.io

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
     },
     "scripts": {
         "test": "@php ./vendor/bin/pest",
+        "test:transport": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./tests/Transport/run.php"
+        ],
         "demo": [
             "Composer\\Config::disableProcessTimeout",
             "@php ./bin/gustav-php dev"

--- a/src/Application.php
+++ b/src/Application.php
@@ -77,6 +77,24 @@ class Application implements RequestHandlerInterface
         Event\Manager::reset();
         View::reset();
 
+        foreach (Discovery::discoverServices() as $service) {
+            $this->services->bind(
+                $service->service,
+                $service->implementation,
+                $service->lifetime,
+            );
+        }
+        foreach (Discovery::discoverServiceProviders() as $provider) {
+            (new $provider())->register($this->services);
+        }
+        foreach (Discovery::discoverMiddlewares() as $middleware) {
+            $this->services->bind(
+                $middleware['class'],
+                $middleware['class'],
+                $middleware['lifetime'],
+            );
+            $this->addMiddleware($middleware['class']);
+        }
         foreach (Discovery::discoverController() as $class) {
             $this->addRoutes([$class]);
         }

--- a/src/Application.php
+++ b/src/Application.php
@@ -11,6 +11,7 @@ use GustavPHP\Gustav\Http\Exception\{HttpException, RequestInputException, Valid
 use GustavPHP\Gustav\Middleware\Pipeline;
 use GustavPHP\Gustav\Router\{Method, Router};
 use GustavPHP\Gustav\Service\Container;
+use InvalidArgumentException;
 use LogicException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response as Psr7Response;
@@ -42,7 +43,7 @@ class Application implements RequestHandlerInterface
      */
     protected array $files = [];
     /**
-     * @var array<MiddlewareInterface>
+     * @var array<class-string<MiddlewareInterface>>
      */
     protected array $middlewares = [];
     /**
@@ -53,6 +54,8 @@ class Application implements RequestHandlerInterface
      * @var array<int,ResponseHandler>
      */
     protected array $responseHandlers = [];
+
+    protected Container $services;
 
     /**
      * Creates a new application instance.
@@ -65,6 +68,10 @@ class Application implements RequestHandlerInterface
         Configuration $configuration
     ) {
         self::$configuration = $configuration;
+        $this->services = new Container();
+        $this->services
+            ->singleton(Configuration::class, $configuration)
+            ->singleton(self::class, $this);
         Router::reset();
         Serializer\Manager::reset();
         Event\Manager::reset();
@@ -98,9 +105,18 @@ class Application implements RequestHandlerInterface
 
     /**
      * Add application-wide middleware.
+     *
+     * @param class-string<MiddlewareInterface> ...$middlewares
      */
-    public function addMiddleware(MiddlewareInterface ...$middlewares): self
+    public function addMiddleware(string ...$middlewares): self
     {
+        foreach ($middlewares as $middleware) {
+            if (!is_a($middleware, MiddlewareInterface::class, true)) {
+                throw new InvalidArgumentException(
+                    "Middleware '{$middleware}' must implement " . MiddlewareInterface::class,
+                );
+            }
+        }
         array_push($this->middlewares, ...$middlewares);
 
         return $this;
@@ -127,16 +143,28 @@ class Application implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $scope = null;
+
         try {
+            $this->services->build();
+            $scope = $this->services->createRequestScope($request);
             $path = ltrim($request->getUri()->getPath(), '/');
             $request = $request->withAttribute('Gustav-Path', $path);
+            $scope->setRequest($request);
 
             return (new Pipeline(
-                $this->middlewares,
-                new CallableRequestHandler($this->handleRoutedRequestSafely(...)),
+                $this->resolveMiddlewares($this->middlewares, $scope),
+                new CallableRequestHandler(
+                    fn (ServerRequestInterface $nextRequest): ResponseInterface => $this->handleRoutedRequestSafely(
+                        $nextRequest,
+                        $scope,
+                    ),
+                ),
             ))->handle($request);
         } catch (Throwable $th) {
             return $this->renderException($th);
+        } finally {
+            $scope?->release();
         }
     }
 
@@ -151,12 +179,21 @@ class Application implements RequestHandlerInterface
     }
 
     /**
+     * Access application service registration before request handling begins.
+     */
+    public function services(): Container
+    {
+        return $this->services;
+    }
+
+    /**
      * Starts the application.
      *
      * @return void
      */
     public function start(): void
     {
+        $this->services->build();
         $worker = Worker::create();
         $factory = new Psr17Factory();
         $psr7 = new PSR7Worker($worker, $factory, $factory, $factory);
@@ -216,18 +253,23 @@ class Application implements RequestHandlerInterface
     /**
      * Invoke the matched controller.
      */
-    protected function dispatchRequest(ServerRequestInterface $request): ResponseInterface
-    {
+    protected function dispatchRequest(
+        ServerRequestInterface $request,
+        Container $scope,
+    ): ResponseInterface {
         $route = $request->getAttribute('Gustav-Route');
         $controller = $request->getAttribute('Gustav-Controller');
         if (!$route instanceof Attribute\Route || !$controller instanceof ControllerFactory) {
             throw new LogicException('Request route has not been initialized');
         }
 
-        $dependencies = new Container();
-        $dependencies->addDependency([ServerRequestInterface::class => fn () => $request]);
-        $dependencies->build();
-        $instance = $dependencies->make($controller->getClass());
+        $scope->setRequest($request);
+        $instance = $scope->make($controller->getClass());
+        if (!$instance instanceof Controller\Base) {
+            throw new LogicException(
+                "Controller '{$controller->getClass()}' must extend " . Controller\Base::class,
+            );
+        }
         $requestBinder = $this->requestBinders[spl_object_id($route)] ?? null;
         if ($requestBinder === null) {
             throw new LogicException('Request binder has not been initialized');
@@ -265,8 +307,11 @@ class Application implements RequestHandlerInterface
     /**
      * Resolve a route and run its controller and method middleware.
      */
-    protected function handleRoutedRequest(ServerRequestInterface $request): ResponseInterface
-    {
+    protected function handleRoutedRequest(
+        ServerRequestInterface $request,
+        Container $scope,
+    ): ResponseInterface {
+        $scope->setRequest($request);
         $path = $request->getAttribute('Gustav-Path');
         if (!is_string($path)) {
             throw new LogicException('Request path has not been initialized');
@@ -282,15 +327,22 @@ class Application implements RequestHandlerInterface
             throw new LogicException("Controller '{$route->getClass()}' has not been registered");
         }
 
-        $middlewares = $controller->getMiddlewares($route->getFunction());
+        $middlewares = $this->resolveMiddlewares(
+            $controller->getMiddlewareClasses($route->getFunction()),
+            $scope,
+        );
         $request = $request
             ->withAttribute('Gustav-Route', $route)
-            ->withAttribute('Gustav-Controller', $controller)
-            ->withAttribute('Gustav-Middlewares', $middlewares);
+            ->withAttribute('Gustav-Controller', $controller);
 
         return (new Pipeline(
             $middlewares,
-            new CallableRequestHandler($this->dispatchRequest(...)),
+            new CallableRequestHandler(
+                fn (ServerRequestInterface $nextRequest): ResponseInterface => $this->dispatchRequest(
+                    $nextRequest,
+                    $scope,
+                ),
+            ),
         ))->handle($request);
     }
 
@@ -298,10 +350,12 @@ class Application implements RequestHandlerInterface
      * Convert route and controller exceptions inside the application middleware
      * pipeline so outer middleware can inspect the resulting error response.
      */
-    protected function handleRoutedRequestSafely(ServerRequestInterface $request): ResponseInterface
-    {
+    protected function handleRoutedRequestSafely(
+        ServerRequestInterface $request,
+        Container $scope,
+    ): ResponseInterface {
         try {
-            return $this->handleRoutedRequest($request);
+            return $this->handleRoutedRequest($request, $scope);
         } catch (Throwable $throwable) {
             return $this->renderException($throwable);
         }
@@ -339,8 +393,13 @@ class Application implements RequestHandlerInterface
      */
     protected function registerRoute(string $class): void
     {
-        $controller = new ControllerFactory($class);
         $reflector = new ReflectionClass($class);
+        if (!$reflector->isSubclassOf(Controller\Base::class)) {
+            throw new InvalidArgumentException(
+                "Controller '{$class}' must extend " . Controller\Base::class,
+            );
+        }
+        $controller = new ControllerFactory($class, $reflector);
         $this->addMethods($reflector);
         $this->controllers[$class] = $controller;
     }
@@ -448,5 +507,23 @@ class Application implements RequestHandlerInterface
         $routeId = spl_object_id($route);
         $this->requestBinders[$routeId] = $requestBinder;
         $this->responseHandlers[$routeId] = $responseHandler;
+    }
+
+    /**
+     * @param array<class-string<MiddlewareInterface>> $classes
+     * @return array<MiddlewareInterface>
+     */
+    private function resolveMiddlewares(array $classes, Container $scope): array
+    {
+        return array_map(function (string $class) use ($scope): MiddlewareInterface {
+            $middleware = $scope->get($class);
+            if (!$middleware instanceof MiddlewareInterface) {
+                throw new LogicException(
+                    "Service '{$class}' must resolve to " . MiddlewareInterface::class,
+                );
+            }
+
+            return $middleware;
+        }, $classes);
     }
 }

--- a/src/Attribute/GlobalMiddleware.php
+++ b/src/Attribute/GlobalMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use GustavPHP\Gustav\Service\Lifetime;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class GlobalMiddleware
+{
+    public function __construct(
+        private int $priority = 0,
+        private Lifetime $lifetime = Lifetime::Request,
+    ) {
+    }
+
+    public function getLifetime(): Lifetime
+    {
+        return $this->lifetime;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Attribute/Middleware.php
+++ b/src/Attribute/Middleware.php
@@ -3,6 +3,7 @@
 namespace GustavPHP\Gustav\Attribute;
 
 use Attribute;
+use InvalidArgumentException;
 use Psr\Http\Server\MiddlewareInterface;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
@@ -11,18 +12,23 @@ class Middleware
     /**
      * Middleware Attribute.
      *
-     * @param MiddlewareInterface $instance
+     * @param class-string<MiddlewareInterface> $class
      * @return void
      */
-    public function __construct(protected MiddlewareInterface $instance)
+    public function __construct(protected string $class)
     {
+        if (!is_a($class, MiddlewareInterface::class, true)) {
+            throw new InvalidArgumentException(
+                "Middleware '{$class}' must implement " . MiddlewareInterface::class,
+            );
+        }
     }
 
     /**
-     * @return MiddlewareInterface
+     * @return class-string<MiddlewareInterface>
      */
-    public function getInstance(): MiddlewareInterface
+    public function getClass(): string
     {
-        return $this->instance;
+        return $this->class;
     }
 }

--- a/src/Attribute/Service.php
+++ b/src/Attribute/Service.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use GustavPHP\Gustav\Service\Lifetime;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Service
+{
+    /**
+     * @param null|class-string $as
+     */
+    public function __construct(
+        private ?string $as = null,
+        private Lifetime $lifetime = Lifetime::Request,
+    ) {
+        if (
+            $as !== null
+            && !class_exists($as)
+            && !interface_exists($as)
+        ) {
+            throw new InvalidArgumentException("Service abstraction '{$as}' does not exist");
+        }
+    }
+
+    public function getLifetime(): Lifetime
+    {
+        return $this->lifetime;
+    }
+
+    /** @return null|class-string */
+    public function getService(): ?string
+    {
+        return $this->as;
+    }
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -63,6 +63,18 @@ readonly class Configuration
          * @var array<string>
          */
         public array $serializerNamespaces = [],
+        /**
+         * Namespace containing discoverable services.
+         *
+         * @var array<string>
+         */
+        public array $serviceNamespaces = [],
+        /**
+         * Namespace containing discoverable application-wide middleware.
+         *
+         * @var array<string>
+         */
+        public array $middlewareNamespaces = [],
     ) {
     }
 }

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -5,18 +5,32 @@ namespace GustavPHP\Gustav\Controller;
 use GustavPHP\Gustav\Attribute\Middleware;
 use Psr\Http\Server\MiddlewareInterface;
 use ReflectionClass;
-use ReflectionException;
 
 class ControllerFactory
 {
+    /** @var array<string, array<class-string<MiddlewareInterface>>> */
+    private array $methodMiddlewares = [];
+    /** @var array<class-string<MiddlewareInterface>> */
+    private array $middlewares;
+
     /**
      * ControllerFactory constructor.
      *
      * @param class-string<Base> $class
      * @return void
      */
-    public function __construct(protected string $class)
-    {
+    public function __construct(
+        protected string $class,
+        ?ReflectionClass $reflection = null,
+    ) {
+        $reflection ??= new ReflectionClass($class);
+        $this->middlewares = $this->compileMiddlewares($reflection->getAttributes(Middleware::class));
+
+        foreach ($reflection->getMethods() as $method) {
+            $this->methodMiddlewares[$method->getName()] = $this->compileMiddlewares(
+                $method->getAttributes(Middleware::class),
+            );
+        }
     }
 
     /**
@@ -30,25 +44,26 @@ class ControllerFactory
     }
 
     /**
-     * Get the middlewares for the controller.
+     * Get the compiled middleware classes for the controller and method.
      *
-     * @return array<MiddlewareInterface>
-     * @throws ReflectionException
+     * @return array<class-string<MiddlewareInterface>>
      */
-    public function getMiddlewares(?string $method = null): array
+    public function getMiddlewareClasses(?string $method = null): array
     {
-        $reflection = new ReflectionClass($this->class);
-        $attributes = $reflection->getAttributes(Middleware::class);
+        return [
+            ...$this->middlewares,
+            ...($method === null ? [] : ($this->methodMiddlewares[$method] ?? [])),
+        ];
+    }
 
-        if ($method !== null) {
-            $attributes = [
-                ...$attributes,
-                ...$reflection->getMethod($method)->getAttributes(Middleware::class),
-            ];
-        }
-
+    /**
+     * @param array<\ReflectionAttribute<Middleware>> $attributes
+     * @return array<class-string<MiddlewareInterface>>
+     */
+    private function compileMiddlewares(array $attributes): array
+    {
         return array_map(
-            fn ($attribute) => $attribute->newInstance()->getInstance(),
+            fn ($attribute): string => $attribute->newInstance()->getClass(),
             $attributes,
         );
     }

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -3,7 +3,11 @@
 namespace GustavPHP\Gustav;
 
 use Exception;
+use GustavPHP\Gustav\Service\{Provider, Registration};
 use HaydenPierce\ClassFinder\ClassFinder;
+use InvalidArgumentException;
+use Psr\Http\Server\MiddlewareInterface;
+use ReflectionClass;
 
 class Discovery
 {
@@ -33,6 +37,47 @@ class Discovery
             yield $event;
         }
     }
+
+    /**
+     * @return array<int, array{
+     *     class: class-string<MiddlewareInterface>,
+     *     lifetime: Service\Lifetime,
+     *     priority: int
+     * }>
+     * @throws Exception
+     */
+    public static function discoverMiddlewares(): array
+    {
+        $middlewares = [];
+
+        foreach (self::discoverClasses('Middlewares', 'middlewareNamespaces') as $class) {
+            $reflection = new ReflectionClass($class);
+            $attributes = $reflection->getAttributes(Attribute\GlobalMiddleware::class);
+            if ($attributes === []) {
+                continue;
+            }
+            if (!is_a($class, MiddlewareInterface::class, true)) {
+                throw new InvalidArgumentException(
+                    "Global middleware '{$class}' must implement " . MiddlewareInterface::class,
+                );
+            }
+
+            $metadata = $attributes[0]->newInstance();
+            $middlewares[] = [
+                'class' => $class,
+                'lifetime' => $metadata->getLifetime(),
+                'priority' => $metadata->getPriority(),
+            ];
+        }
+
+        usort(
+            $middlewares,
+            fn (array $left, array $right): int => $left['priority'] <=> $right['priority']
+                ?: strcmp($left['class'], $right['class']),
+        );
+
+        return $middlewares;
+    }
     /**
      * @return iterable<class-string<Serializer\Base>>
      * @throws Exception
@@ -44,6 +89,55 @@ class Discovery
              * @var class-string<Serializer\Base> $serializer
              */
             yield $serializer;
+        }
+    }
+
+    /**
+     * @return iterable<class-string<Provider>>
+     * @throws Exception
+     */
+    public static function discoverServiceProviders(): iterable
+    {
+        foreach (self::discoverClasses('Services', 'serviceNamespaces') as $class) {
+            if (!is_a($class, Provider::class, true)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($class);
+            $constructor = $reflection->getConstructor();
+            if (
+                !$reflection->isInstantiable()
+                || ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0)
+            ) {
+                throw new InvalidArgumentException(
+                    "Service provider '{$class}' must have a public zero-argument constructor",
+                );
+            }
+
+            yield $class;
+        }
+    }
+
+    /**
+     * @return iterable<Registration>
+     * @throws Exception
+     */
+    public static function discoverServices(): iterable
+    {
+        foreach (self::discoverClasses('Services', 'serviceNamespaces') as $class) {
+            $reflection = new ReflectionClass($class);
+            $attributes = $reflection->getAttributes(Attribute\Service::class);
+            if ($attributes === []) {
+                continue;
+            }
+
+            $metadata = $attributes[0]->newInstance();
+
+            yield new Registration(
+                $metadata->getService() ?? $class,
+                $class,
+                $metadata->getLifetime(),
+            );
         }
     }
     /**
@@ -65,6 +159,34 @@ class Discovery
                 if (is_subclass_of($class, $base)) {
                     yield $class;
                 }
+            }
+        }
+    }
+
+    /**
+     * @return iterable<class-string>
+     * @throws Exception
+     */
+    private static function discoverClasses(string $namespace, string $configurationKey): iterable
+    {
+        $seen = [];
+        $default = Application::$configuration->namespace . '\\' . $namespace;
+
+        foreach ([$default, ...Application::$configuration->{$configurationKey}] as $current) {
+            foreach (ClassFinder::getClassesInNamespace($current, ClassFinder::RECURSIVE_MODE) as $class) {
+                if (
+                    !class_exists($class)
+                    && !interface_exists($class)
+                    && !trait_exists($class)
+                ) {
+                    throw new InvalidArgumentException("Discovered class '{$class}' does not exist");
+                }
+                if (isset($seen[$class])) {
+                    continue;
+                }
+                $seen[$class] = true;
+
+                yield $class;
             }
         }
     }

--- a/src/Service/Container.php
+++ b/src/Service/Container.php
@@ -2,198 +2,337 @@
 
 namespace GustavPHP\Gustav\Service;
 
-use Closure;
-use GustavPHP\Gustav\Controller\Base;
 use InvalidArgumentException;
 use LogicException;
+use Psr\Http\Message\ServerRequestInterface;
 use ReflectionClass;
-use ReflectionFunction;
 use ReflectionNamedType;
 use ReflectionParameter;
 
 class Container
 {
-    protected bool $built = false;
-    /**
-     * @var array<string, callable(self): mixed|object>
-     */
-    protected array $definitions = [];
+    private bool $released = false;
 
-    /**
-     * @var array<string, mixed>
-     */
-    protected array $resolved = [];
+    /** @var array<string, mixed> */
+    private array $resolved = [];
 
-    /**
-     * @var array<string, bool>
-     */
-    protected array $resolving = [];
+    /** @var array<string, bool> */
+    private array $resolving = [];
+    private Container $root;
 
-    /**
-     * Register dependencies that can later be resolved by the container.
-     *
-     * @param array<string, callable(self): mixed|object> $definitions Callables may
-     * accept the container as their only argument.
-     * @return void
-     */
-    public function addDependency(array $definitions): void
+    private ContainerState $state;
+
+    public function __construct()
     {
-        foreach ($definitions as $id => $factory) {
-            if (!is_string($id) || $id === '') {
-                throw new InvalidArgumentException(
-                    'Dependency id must be a non-empty string',
-                );
-            }
-            if (!is_callable($factory) && !is_object($factory)) {
-                throw new InvalidArgumentException(
-                    "Definition for '{$id}' must be an object or callable",
-                );
-            }
-
-            $this->definitions[$id] = $factory;
-        }
+        $this->root = $this;
+        $this->state = new ContainerState();
     }
 
     /**
-     * Finalizes the container configuration. Included for API parity with the
-     * previous php-di integration.
+     * Bind an abstraction to an injectable implementation.
+     *
+     * @param class-string $implementation
+     */
+    public function bind(
+        string $id,
+        string $implementation,
+        Lifetime $lifetime = Lifetime::Request,
+    ): self {
+        if (!class_exists($implementation)) {
+            throw new InvalidArgumentException("Service implementation '{$implementation}' does not exist");
+        }
+        if (
+            (class_exists($id) || interface_exists($id))
+            && !is_a($implementation, $id, true)
+        ) {
+            throw new InvalidArgumentException("{$implementation} must implement or extend {$id}");
+        }
+
+        return $this->register($id, $implementation, $lifetime);
+    }
+
+    /**
+     * Freeze service registration. Calling this method more than once is safe.
      */
     public function build(): void
     {
-        $this->built = true;
+        $this->assertRoot();
+        $this->state->built = true;
     }
 
     /**
-     * Create a new instance of the given class with constructor injection.
-     *
-     * @param class-string<Base> $class
-     * @return Base
+     * Create the isolated service scope for one HTTP request.
      */
-    public function make(string $class): Base
+    public function createRequestScope(ServerRequestInterface $request): self
     {
-        if (!$this->built) {
+        $this->assertRoot();
+        $this->assertBuilt();
+
+        $scope = new self();
+        $scope->root = $this;
+        $scope->state = $this->state;
+        $scope->resolved[ServerRequestInterface::class] = $request;
+
+        return $scope;
+    }
+
+    /**
+     * Resolve a service from the active container.
+     */
+    public function get(string $id): mixed
+    {
+        $this->assertActive();
+        $this->assertBuilt();
+
+        if ($id === self::class) {
+            return $this;
+        }
+        if (array_key_exists($id, $this->resolved)) {
+            return $this->resolved[$id];
+        }
+
+        $definition = $this->state->definitions[$id] ?? null;
+        if ($definition === null) {
+            if (!class_exists($id)) {
+                throw new InvalidArgumentException("Unable to resolve '{$id}'");
+            }
+            $definition = new Definition(Lifetime::Request, $id);
+        }
+
+        return match ($definition->lifetime) {
+            Lifetime::Singleton => $this->root->resolveSingleton($id, $definition),
+            Lifetime::Request => $this->resolveRequest($id, $definition),
+            Lifetime::Transient => $this->create($id, $definition),
+        };
+    }
+
+    /**
+     * Report whether an identifier has an explicit definition or can be autowired.
+     */
+    public function has(string $id): bool
+    {
+        return array_key_exists($id, $this->resolved)
+            || array_key_exists($id, $this->state->definitions)
+            || class_exists($id);
+    }
+
+    /**
+     * Create an uncached class instance while resolving its dependencies through
+     * the active container.
+     *
+     * @param class-string $class
+     */
+    public function make(string $class): object
+    {
+        $this->assertActive();
+        $this->assertBuilt();
+
+        return $this->autowire($class);
+    }
+
+    /**
+     * Release all references owned by this request scope.
+     */
+    public function release(): void
+    {
+        if ($this->root === $this) {
+            throw new LogicException('The application service container cannot be released');
+        }
+
+        $this->resolved = [];
+        $this->resolving = [];
+        $this->released = true;
+    }
+
+    /**
+     * Register one service instance per HTTP request.
+     */
+    public function request(string $id, mixed $definition = null): self
+    {
+        return $this->register($id, $definition ?? $id, Lifetime::Request);
+    }
+
+    /**
+     * Keep direct request injection aligned with the request passed down by
+     * middleware.
+     */
+    public function setRequest(ServerRequestInterface $request): void
+    {
+        $this->assertRequestScope();
+        $this->assertActive();
+        $this->resolved[ServerRequestInterface::class] = $request;
+    }
+
+    /**
+     * Register one service shared by the entire application process.
+     */
+    public function singleton(string $id, mixed $definition = null): self
+    {
+        return $this->register($id, $definition ?? $id, Lifetime::Singleton);
+    }
+
+    /**
+     * Register a service that is recreated for every resolution.
+     */
+    public function transient(string $id, mixed $definition = null): self
+    {
+        return $this->register($id, $definition ?? $id, Lifetime::Transient);
+    }
+
+    private function assertActive(): void
+    {
+        if ($this->released) {
+            throw new LogicException('Request service scope has already been released');
+        }
+    }
+
+    private function assertBuilt(): void
+    {
+        if (!$this->state->built) {
             throw new LogicException('Container not built');
         }
+    }
 
-        $instance = $this->autowire($class);
-        if (!$instance instanceof Base) {
-            throw new LogicException("{$class} must extend " . Base::class);
+    private function assertRequestScope(): void
+    {
+        if ($this->root === $this) {
+            throw new LogicException('This operation requires an active request scope');
         }
+    }
 
-        return $instance;
+    private function assertRoot(): void
+    {
+        if ($this->root !== $this) {
+            throw new LogicException('Services can only be registered on the application container');
+        }
     }
 
     /**
      * Instantiate a class and resolve its constructor dependencies.
      *
      * @param class-string $class
-     * @return object
      */
-    protected function autowire(string $class): object
+    private function autowire(string $class): object
     {
         if (!class_exists($class)) {
             throw new InvalidArgumentException("Unable to resolve '{$class}'");
         }
 
-        $reflector = new ReflectionClass($class);
+        $reflector = $this->state->reflectors[$class] ??= new ReflectionClass($class);
         if (!$reflector->isInstantiable()) {
             throw new InvalidArgumentException("{$class} is not instantiable");
         }
 
         $constructor = $reflector->getConstructor();
-        if (
-            $constructor === null ||
-            $constructor->getNumberOfParameters() === 0
-        ) {
-            return new $class();
+        if ($constructor === null || $constructor->getNumberOfParameters() === 0) {
+            return $reflector->newInstance();
         }
 
         $dependencies = array_map(
-            fn (ReflectionParameter $parameter) => $this->resolveParameter(
-                $class,
-                $parameter,
-            ),
+            fn (ReflectionParameter $parameter): mixed => $this->resolveParameter($class, $parameter),
             $constructor->getParameters(),
         );
 
         return $reflector->newInstanceArgs($dependencies);
     }
 
-    /**
-     * Execute a callable definition with optional container injection.
-     *
-     * @param string $id
-     * @param callable $definition
-     * @return mixed
-     */
-    protected function executeDefinition(
-        string $id,
-        callable $definition,
-    ): mixed {
-        $callable = Closure::fromCallable($definition);
-        $reflection = new ReflectionFunction($callable);
-        $parameterCount = $reflection->getNumberOfParameters();
+    private function create(string $id, Definition $definition): mixed
+    {
+        if (isset($this->resolving[$id])) {
+            $chain = implode(' -> ', [...array_keys($this->resolving), $id]);
+            throw new LogicException("Circular dependency detected: {$chain}");
+        }
 
-        if ($parameterCount > 1) {
+        $this->resolving[$id] = true;
+
+        try {
+            $resolver = $definition->resolver;
+            if (is_string($resolver)) {
+                if (!class_exists($resolver)) {
+                    throw new LogicException("Service implementation '{$resolver}' is no longer available");
+                }
+                $value = $this->autowire($resolver);
+            } elseif ($resolver instanceof Factory) {
+                $value = $resolver->invoke($this);
+            } else {
+                $value = $resolver;
+            }
+
+            if (
+                (class_exists($id) || interface_exists($id))
+                && !$value instanceof $id
+            ) {
+                $type = get_debug_type($value);
+                throw new InvalidArgumentException("Definition for '{$id}' returned {$type}");
+            }
+
+            return $value;
+        } finally {
+            unset($this->resolving[$id]);
+        }
+    }
+
+    private function register(string $id, mixed $resolver, Lifetime $lifetime): self
+    {
+        $this->assertRoot();
+        if ($this->state->built) {
+            throw new LogicException('Service container is already built');
+        }
+        if ($id === '') {
+            throw new InvalidArgumentException('Service id must be a non-empty string');
+        }
+        if (is_string($resolver)) {
+            if (!class_exists($resolver)) {
+                throw new InvalidArgumentException("Service implementation '{$resolver}' does not exist");
+            }
+            $reflection = new ReflectionClass($resolver);
+            if (!$reflection->isInstantiable()) {
+                throw new InvalidArgumentException("Service implementation '{$resolver}' is not instantiable");
+            }
+            if (
+                (class_exists($id) || interface_exists($id))
+                && !is_a($resolver, $id, true)
+            ) {
+                throw new InvalidArgumentException("{$resolver} must implement or extend {$id}");
+            }
+            $this->state->reflectors[$resolver] = $reflection;
+        } elseif (
+            is_callable($resolver)
+            && ($resolver instanceof \Closure || is_array($resolver))
+        ) {
+            $resolver = Factory::compile($id, $resolver);
+        } elseif (!is_object($resolver)) {
             throw new InvalidArgumentException(
-                "Definition for '{$id}' must accept 0 or 1 parameter, {$parameterCount} given",
+                "Definition for '{$id}' must be a class, object, or callable",
+            );
+        }
+        if (
+            is_object($resolver)
+            && !$resolver instanceof Factory
+            && (class_exists($id) || interface_exists($id))
+            && !$resolver instanceof $id
+        ) {
+            throw new InvalidArgumentException(
+                "Object definition for '{$id}' must implement or extend {$id}",
+            );
+        }
+        if (is_object($resolver) && !$resolver instanceof Factory && $lifetime !== Lifetime::Singleton) {
+            throw new InvalidArgumentException(
+                "Object definition for '{$id}' must use the singleton lifetime",
             );
         }
 
-        return $parameterCount === 0 ? $callable() : $callable($this);
+        $this->state->definitions[$id] = new Definition($lifetime, $resolver);
+
+        return $this;
     }
 
-    /**
-     * Resolve a dependency by identifier.
-     *
-     * @param string $id
-     * @return mixed
-     */
-    protected function resolve(string $id): mixed
+    private function resolveParameter(string $context, ReflectionParameter $parameter): mixed
     {
-        if (array_key_exists($id, $this->resolved)) {
-            return $this->resolved[$id];
-        }
-
-        if (isset($this->resolving[$id])) {
-            throw new LogicException("Unable to resolve '{$id}'");
-        }
-        $this->resolving[$id] = true;
-
-        if (array_key_exists($id, $this->definitions)) {
-            $definition = $this->definitions[$id];
-            $value = is_callable($definition)
-                ? $this->executeDefinition($id, $definition)
-                : $definition;
-        } else {
-            if (!class_exists($id)) {
-                throw new InvalidArgumentException("Unable to resolve '{$id}'");
-            }
-            $value = $this->autowire($id);
-        }
-
-        unset($this->resolving[$id]);
-
-        $this->resolved[$id] = $value;
-
-        return $value;
-    }
-
-    /**
-     * Resolve a single constructor parameter.
-     *
-     * @param string $context
-     * @param ReflectionParameter $parameter
-     * @return mixed
-     */
-    protected function resolveParameter(
-        string $context,
-        ReflectionParameter $parameter,
-    ): mixed {
         $type = $parameter->getType();
 
         if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
-            return $this->resolve($type->getName());
+            return $this->get($type->getName());
         }
 
         if ($parameter->isDefaultValueAvailable()) {
@@ -207,5 +346,31 @@ class Container
         throw new InvalidArgumentException(
             "Unable to resolve parameter \${$parameter->getName()} for {$context}::__construct()",
         );
+    }
+
+    private function resolveRequest(string $id, Definition $definition): mixed
+    {
+        if ($this->root === $this) {
+            throw new LogicException("Request-scoped service '{$id}' requires an active request scope");
+        }
+
+        if (array_key_exists($id, $this->resolved)) {
+            return $this->resolved[$id];
+        }
+
+        $this->resolved[$id] = $this->create($id, $definition);
+
+        return $this->resolved[$id];
+    }
+
+    private function resolveSingleton(string $id, Definition $definition): mixed
+    {
+        if (array_key_exists($id, $this->state->singletons)) {
+            return $this->state->singletons[$id];
+        }
+
+        $this->state->singletons[$id] = $this->create($id, $definition);
+
+        return $this->state->singletons[$id];
     }
 }

--- a/src/Service/ContainerState.php
+++ b/src/Service/ContainerState.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GustavPHP\Gustav\Service;
+
+use ReflectionClass;
+
+/** @internal */
+final class ContainerState
+{
+    public bool $built = false;
+
+    /** @var array<string, Definition> */
+    public array $definitions = [];
+
+    /** @var array<class-string, ReflectionClass<object>> */
+    public array $reflectors = [];
+
+    /** @var array<string, mixed> */
+    public array $singletons = [];
+}

--- a/src/Service/Definition.php
+++ b/src/Service/Definition.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GustavPHP\Gustav\Service;
+
+/** @internal */
+final readonly class Definition
+{
+    public function __construct(
+        public Lifetime $lifetime,
+        public mixed $resolver,
+    ) {
+    }
+}

--- a/src/Service/Factory.php
+++ b/src/Service/Factory.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace GustavPHP\Gustav\Service;
+
+use Closure;
+use InvalidArgumentException;
+use ReflectionFunction;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+/** @internal */
+final readonly class Factory
+{
+    private function __construct(
+        private Closure $factory,
+        private bool $receivesContainer,
+    ) {
+    }
+
+    public static function compile(string $id, callable $factory): self
+    {
+        $closure = Closure::fromCallable($factory);
+        $reflection = new ReflectionFunction($closure);
+        $parameters = $reflection->getParameters();
+
+        if (count($parameters) > 1) {
+            throw new InvalidArgumentException(
+                "Definition for '{$id}' must accept 0 or 1 parameter, " . count($parameters) . ' given',
+            );
+        }
+
+        $parameter = $parameters[0] ?? null;
+        if ($parameter !== null && !self::acceptsContainer($parameter->getType())) {
+            throw new InvalidArgumentException(
+                "Factory parameter for '{$id}' must accept " . Container::class,
+            );
+        }
+
+        return new self($closure, $parameter !== null);
+    }
+
+    public function invoke(Container $container): mixed
+    {
+        return $this->receivesContainer
+            ? ($this->factory)($container)
+            : ($this->factory)();
+    }
+
+    private static function acceptsContainer(?ReflectionType $type): bool
+    {
+        if ($type === null) {
+            return true;
+        }
+        if ($type instanceof ReflectionNamedType) {
+            if ($type->isBuiltin()) {
+                return in_array($type->getName(), ['mixed', 'object'], true);
+            }
+
+            return is_a(Container::class, $type->getName(), true);
+        }
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $member) {
+                if ($member instanceof ReflectionNamedType && $member->getName() === 'null') {
+                    continue;
+                }
+                if (self::acceptsContainer($member)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        if ($type instanceof ReflectionIntersectionType) {
+            foreach ($type->getTypes() as $member) {
+                if (!self::acceptsContainer($member)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Service/Lifetime.php
+++ b/src/Service/Lifetime.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GustavPHP\Gustav\Service;
+
+enum Lifetime
+{
+    case Request;
+    case Singleton;
+    case Transient;
+}

--- a/src/Service/Provider.php
+++ b/src/Service/Provider.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GustavPHP\Gustav\Service;
+
+interface Provider
+{
+    public function register(Container $services): void;
+}

--- a/src/Service/Registration.php
+++ b/src/Service/Registration.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GustavPHP\Gustav\Service;
+
+/** @internal */
+final readonly class Registration
+{
+    /**
+     * @param class-string $service
+     * @param class-string $implementation
+     */
+    public function __construct(
+        public string $service,
+        public string $implementation,
+        public Lifetime $lifetime,
+    ) {
+    }
+}

--- a/tests/Fixtures/Middlewares/DiscoveredMiddleware.php
+++ b/tests/Fixtures/Middlewares/DiscoveredMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Middlewares;
+
+use GustavPHP\Gustav\Attribute\GlobalMiddleware;
+use GustavPHP\Gustav\Middleware\Base;
+use GustavPHP\Tests\Fixtures\Services\ProviderContract;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[GlobalMiddleware(priority: -100)]
+class DiscoveredMiddleware extends Base
+{
+    public function __construct(private readonly ProviderContract $service)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler
+            ->handle($request)
+            ->withHeader('X-Discovered-Middleware', $this->service->value());
+    }
+}

--- a/tests/Fixtures/Service/ContainerTestContract.php
+++ b/tests/Fixtures/Service/ContainerTestContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+interface ContainerTestContract
+{
+    public function value(): string;
+}

--- a/tests/Fixtures/Service/ContainerTestImplementation.php
+++ b/tests/Fixtures/Service/ContainerTestImplementation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+class ContainerTestImplementation implements ContainerTestContract
+{
+    public function value(): string
+    {
+        return 'implementation';
+    }
+}

--- a/tests/Fixtures/Service/ContainerTestInvalidSingleton.php
+++ b/tests/Fixtures/Service/ContainerTestInvalidSingleton.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+class ContainerTestInvalidSingleton
+{
+    public function __construct(public ContainerTestRequestService $request)
+    {
+    }
+}

--- a/tests/Fixtures/Service/ContainerTestInvokableService.php
+++ b/tests/Fixtures/Service/ContainerTestInvokableService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+class ContainerTestInvokableService
+{
+    public function __invoke(): string
+    {
+        return 'invoked';
+    }
+}

--- a/tests/Fixtures/Service/ContainerTestRequestService.php
+++ b/tests/Fixtures/Service/ContainerTestRequestService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+class ContainerTestRequestService
+{
+}

--- a/tests/Fixtures/Service/ContainerTestScopedConsumer.php
+++ b/tests/Fixtures/Service/ContainerTestScopedConsumer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class ContainerTestScopedConsumer
+{
+    public function __construct(
+        public ContainerTestRequestService $service,
+        public ServerRequestInterface $request,
+    ) {
+    }
+}

--- a/tests/Fixtures/Service/ContainerTestSingletonService.php
+++ b/tests/Fixtures/Service/ContainerTestSingletonService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+class ContainerTestSingletonService
+{
+}

--- a/tests/Fixtures/Service/ContainerTestTransientService.php
+++ b/tests/Fixtures/Service/ContainerTestTransientService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Service;
+
+class ContainerTestTransientService
+{
+}

--- a/tests/Fixtures/Services/ProviderContract.php
+++ b/tests/Fixtures/Services/ProviderContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Services;
+
+interface ProviderContract
+{
+    public function value(): string;
+}

--- a/tests/Fixtures/Services/ProviderImplementation.php
+++ b/tests/Fixtures/Services/ProviderImplementation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Services;
+
+class ProviderImplementation implements ProviderContract
+{
+    public function value(): string
+    {
+        return 'provider';
+    }
+}

--- a/tests/Fixtures/Services/TestProvider.php
+++ b/tests/Fixtures/Services/TestProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GustavPHP\Tests\Fixtures\Services;
+
+use GustavPHP\Gustav\Service\{Container, Provider};
+
+class TestProvider implements Provider
+{
+    public function register(Container $services): void
+    {
+        $services->bind(ProviderContract::class, ProviderImplementation::class);
+    }
+}

--- a/tests/Integration/Middleware/ControllerTrace.php
+++ b/tests/Integration/Middleware/ControllerTrace.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Middleware;
+
+class ControllerTrace extends Trace
+{
+    public function __construct()
+    {
+        parent::__construct('controller');
+    }
+}

--- a/tests/Integration/Middleware/GlobalInjected.php
+++ b/tests/Integration/Middleware/GlobalInjected.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Middleware;
+
+use GustavPHP\Gustav\Middleware\Base;
+use GustavPHP\Tests\Integration\Services\SingletonState;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Http\Server\RequestHandlerInterface;
+
+class GlobalInjected extends Base
+{
+    public function __construct(private readonly SingletonState $state)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler
+            ->handle($request)
+            ->withHeader('X-Singleton-Service', (string) $this->state->id);
+    }
+}

--- a/tests/Integration/Middleware/GlobalTrace.php
+++ b/tests/Integration/Middleware/GlobalTrace.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Middleware;
+
+class GlobalTrace extends Trace
+{
+    public function __construct()
+    {
+        parent::__construct('global');
+    }
+}

--- a/tests/Integration/Middleware/Injected.php
+++ b/tests/Integration/Middleware/Injected.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Middleware;
+
+use GustavPHP\Gustav\Middleware\Base;
+use GustavPHP\Tests\Integration\Services\RequestState;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Http\Server\RequestHandlerInterface;
+
+class Injected extends Base
+{
+    public function __construct(private readonly RequestState $state)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle(
+            $request->withAttribute('middleware-service', $this->state->id),
+        );
+    }
+}

--- a/tests/Integration/Middleware/RouteTrace.php
+++ b/tests/Integration/Middleware/RouteTrace.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Middleware;
+
+class RouteTrace extends Trace
+{
+    public function __construct()
+    {
+        parent::__construct('route');
+    }
+}

--- a/tests/Integration/Routes/Kernel.php
+++ b/tests/Integration/Routes/Kernel.php
@@ -7,17 +7,16 @@ use GustavPHP\Gustav\Auth\{AuthenticationMiddleware, Identity};
 use GustavPHP\Gustav\Auth\Exception\ForbiddenException;
 use GustavPHP\Gustav\Controller;
 use GustavPHP\Gustav\Http\Exception\HttpException;
-use GustavPHP\Tests\Integration\Auth\HeaderAuthenticator;
-use GustavPHP\Tests\Integration\Middleware\{Block, Legacy, Trace};
+use GustavPHP\Tests\Integration\Middleware\{Block, ControllerTrace, Legacy, RouteTrace};
 use Nyholm\Psr7\Response as Psr7Response;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use RuntimeException;
 
-#[Middleware(new Trace('controller'))]
+#[Middleware(ControllerTrace::class)]
 class Kernel extends Controller\Base
 {
     #[Route('/kernel/auth')]
-    #[Middleware(new AuthenticationMiddleware(new HeaderAuthenticator()))]
+    #[Middleware(AuthenticationMiddleware::class)]
     public function auth(#[AuthUser] Identity $identity): Controller\Response
     {
         return $this->json([
@@ -33,7 +32,7 @@ class Kernel extends Controller\Base
     }
 
     #[Route('/kernel/blocked')]
-    #[Middleware(new Block())]
+    #[Middleware(Block::class)]
     public function blocked(): Controller\Response
     {
         return $this->plaintext('controller should not run');
@@ -58,14 +57,14 @@ class Kernel extends Controller\Base
     }
 
     #[Route('/kernel/legacy')]
-    #[Middleware(new Legacy())]
+    #[Middleware(Legacy::class)]
     public function legacy(#[Request] ServerRequestInterface $request): Controller\Response
     {
         return $this->plaintext(implode(',', $request->getAttribute('middleware-trace')));
     }
 
     #[Route('/kernel/middleware')]
-    #[Middleware(new Trace('route'))]
+    #[Middleware(RouteTrace::class)]
     public function middleware(#[Request] ServerRequestInterface $request): Controller\Response
     {
         return $this->plaintext(implode(',', $request->getAttribute('middleware-trace')));

--- a/tests/Integration/Routes/ServiceLifecycle.php
+++ b/tests/Integration/Routes/ServiceLifecycle.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Routes;
+
+use GustavPHP\Gustav\Attribute\{Middleware, Request, Route};
+use GustavPHP\Gustav\Controller;
+use GustavPHP\Gustav\Http\Exception\HttpException;
+use GustavPHP\Tests\Integration\Middleware\Injected;
+use GustavPHP\Tests\Integration\Services\{Greeting, RequestState, SingletonState, TransientState};
+use Psr\Http\Message\ServerRequestInterface;
+
+class ServiceLifecycle extends Controller\Base
+{
+    public function __construct(
+        private readonly Greeting $greeting,
+        private readonly RequestState $requestState,
+        private readonly SingletonState $singletonState,
+        private readonly TransientState $firstTransient,
+        private readonly TransientState $secondTransient,
+    ) {
+    }
+
+    #[Route('/services/lifecycle/error')]
+    public function error(): Controller\Response
+    {
+        throw new HttpException(418, (string) $this->requestState->id);
+    }
+
+    /**
+     * @return array<string, bool|int|string>
+     */
+    #[Route('/services/lifecycle')]
+    #[Middleware(Injected::class)]
+    public function lifecycle(#[Request] ServerRequestInterface $request): array
+    {
+        return [
+            'greeting' => $this->greeting->message(),
+            'request' => $this->requestState->id,
+            'middleware' => $request->getAttribute('middleware-service'),
+            'singleton' => $this->singletonState->id,
+            'transientsDiffer' => $this->firstTransient !== $this->secondTransient,
+            'path' => $this->requestState->request->getUri()->getPath(),
+        ];
+    }
+}

--- a/tests/Integration/Services/DefaultGreeting.php
+++ b/tests/Integration/Services/DefaultGreeting.php
@@ -2,6 +2,9 @@
 
 namespace GustavPHP\Tests\Integration\Services;
 
+use GustavPHP\Gustav\Attribute\Service;
+
+#[Service(as: Greeting::class)]
 class DefaultGreeting implements Greeting
 {
     public function message(): string

--- a/tests/Integration/Services/DefaultGreeting.php
+++ b/tests/Integration/Services/DefaultGreeting.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Services;
+
+class DefaultGreeting implements Greeting
+{
+    public function message(): string
+    {
+        return 'configured';
+    }
+}

--- a/tests/Integration/Services/Greeting.php
+++ b/tests/Integration/Services/Greeting.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Services;
+
+interface Greeting
+{
+    public function message(): string;
+}

--- a/tests/Integration/Services/HeaderAuthenticator.php
+++ b/tests/Integration/Services/HeaderAuthenticator.php
@@ -1,11 +1,14 @@
 <?php
 
-namespace GustavPHP\Tests\Integration\Auth;
+namespace GustavPHP\Tests\Integration\Services;
 
+use GustavPHP\Gustav\Attribute\Service;
 use GustavPHP\Gustav\Auth\{Authenticator, BearerAuth, Identity};
 use GustavPHP\Gustav\Auth\Exception\UnauthorizedException;
+use GustavPHP\Tests\Integration\Auth\TestIdentity;
 use Psr\Http\Message\ServerRequestInterface;
 
+#[Service(as: Authenticator::class)]
 class HeaderAuthenticator implements Authenticator
 {
     public function authenticate(ServerRequestInterface $request): Identity

--- a/tests/Integration/Services/RequestState.php
+++ b/tests/Integration/Services/RequestState.php
@@ -2,8 +2,10 @@
 
 namespace GustavPHP\Tests\Integration\Services;
 
+use GustavPHP\Gustav\Attribute\Service;
 use Psr\Http\Message\ServerRequestInterface;
 
+#[Service]
 class RequestState
 {
     public readonly int $id;

--- a/tests/Integration/Services/RequestState.php
+++ b/tests/Integration/Services/RequestState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Services;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class RequestState
+{
+    public readonly int $id;
+    private static int $nextId = 0;
+
+    public function __construct(public readonly ServerRequestInterface $request)
+    {
+        $this->id = ++self::$nextId;
+    }
+}

--- a/tests/Integration/Services/SingletonState.php
+++ b/tests/Integration/Services/SingletonState.php
@@ -2,6 +2,10 @@
 
 namespace GustavPHP\Tests\Integration\Services;
 
+use GustavPHP\Gustav\Attribute\Service;
+use GustavPHP\Gustav\Service\Lifetime;
+
+#[Service(lifetime: Lifetime::Singleton)]
 class SingletonState
 {
     public readonly int $id;

--- a/tests/Integration/Services/SingletonState.php
+++ b/tests/Integration/Services/SingletonState.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Services;
+
+class SingletonState
+{
+    public readonly int $id;
+    private static int $nextId = 0;
+
+    public function __construct()
+    {
+        $this->id = ++self::$nextId;
+    }
+}

--- a/tests/Integration/Services/TransientState.php
+++ b/tests/Integration/Services/TransientState.php
@@ -2,6 +2,10 @@
 
 namespace GustavPHP\Tests\Integration\Services;
 
+use GustavPHP\Gustav\Attribute\Service;
+use GustavPHP\Gustav\Service\Lifetime;
+
+#[Service(lifetime: Lifetime::Transient)]
 class TransientState
 {
 }

--- a/tests/Integration/Services/TransientState.php
+++ b/tests/Integration/Services/TransientState.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Services;
+
+class TransientState
+{
+}

--- a/tests/Integration/Tests/DiscoveryTest.php
+++ b/tests/Integration/Tests/DiscoveryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use GustavPHP\Gustav\{Application, Configuration, Mode};
+use Nyholm\Psr7\ServerRequest;
+
+it('discovers application-wide middleware without imperative bootstrap calls', function () {
+    $app = new Application(new Configuration(
+        mode: Mode::Production,
+        namespace: 'GustavPHP\\Tests\\Fixtures',
+        cache: sys_get_temp_dir(),
+    ));
+
+    $response = $app->handle(new ServerRequest('GET', '/missing'));
+
+    expect($response->getStatusCode())->toBe(404)
+        ->and($response->getHeaderLine('X-Discovered-Middleware'))->toBe('provider');
+});

--- a/tests/Integration/Tests/KernelTest.php
+++ b/tests/Integration/Tests/KernelTest.php
@@ -4,7 +4,7 @@ use GustavPHP\Gustav\Http\Exception\HttpException;
 
 use function GustavPHP\Tests\Integration\{createApplication, createClient};
 
-use GustavPHP\Tests\Integration\Middleware\Trace;
+use GustavPHP\Tests\Integration\Middleware\GlobalTrace;
 use Nyholm\Psr7\ServerRequest;
 
 $client = createClient();
@@ -18,7 +18,7 @@ describe('http kernel', function () use ($client) {
     });
 
     it('runs global, controller, and route middleware in order and unwinds the response', function () {
-        $app = createApplication()->addMiddleware(new Trace('global'));
+        $app = createApplication()->addMiddleware(GlobalTrace::class);
         $response = $app->handle(new ServerRequest('GET', '/kernel/middleware'));
 
         expect((string) $response->getBody())->toBe('global,controller,route')
@@ -62,7 +62,7 @@ describe('http kernel', function () use ($client) {
     });
 
     it('lets application middleware inspect mapped error responses', function () {
-        $app = createApplication()->addMiddleware(new Trace('global'));
+        $app = createApplication()->addMiddleware(GlobalTrace::class);
         $response = $app->handle(new ServerRequest('GET', '/missing'));
 
         expect($response->getStatusCode())->toBe(404)

--- a/tests/Integration/Tests/ServiceLifecycleTest.php
+++ b/tests/Integration/Tests/ServiceLifecycleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use function GustavPHP\Tests\Integration\createApplication;
+
+use GustavPHP\Tests\Integration\Middleware\GlobalInjected;
+use Nyholm\Psr7\ServerRequest;
+
+describe('application services', function () {
+    it('resolves configured services and injectable middleware with explicit lifetimes', function () {
+        $app = createApplication()->addMiddleware(GlobalInjected::class);
+
+        $firstResponse = $app->handle(new ServerRequest('GET', '/services/lifecycle'));
+        $secondResponse = $app->handle(new ServerRequest('GET', '/services/lifecycle'));
+        $first = json_decode((string) $firstResponse->getBody(), true);
+        $second = json_decode((string) $secondResponse->getBody(), true);
+
+        expect($firstResponse->getStatusCode())->toBe(200)
+            ->and($first['greeting'])->toBe('configured')
+            ->and($first['request'])->toBe($first['middleware'])
+            ->and($first['transientsDiffer'])->toBeTrue()
+            ->and($first['path'])->toBe('/services/lifecycle')
+            ->and($first['request'])->not->toBe($second['request'])
+            ->and($first['singleton'])->toBe($second['singleton'])
+            ->and($firstResponse->getHeaderLine('X-Singleton-Service'))->toBe((string) $first['singleton'])
+            ->and($secondResponse->getHeaderLine('X-Singleton-Service'))->toBe((string) $second['singleton']);
+    });
+
+    it('releases request services after failures', function () {
+        $app = createApplication();
+
+        $failed = $app->handle(new ServerRequest('GET', '/services/lifecycle/error'));
+        $next = $app->handle(new ServerRequest('GET', '/services/lifecycle'));
+        $failure = json_decode((string) $failed->getBody(), true);
+        $body = json_decode((string) $next->getBody(), true);
+
+        expect($failed->getStatusCode())->toBe(418)
+            ->and($next->getStatusCode())->toBe(200)
+            ->and($failure['error']['message'])->not->toBe((string) $body['request']);
+    });
+
+    it('freezes service configuration when request handling begins', function () {
+        $app = createApplication();
+        $app->handle(new ServerRequest('GET', '/responses/plaintext'));
+
+        $app->services()->singleton(stdClass::class);
+    })->throws(LogicException::class, 'already built');
+});

--- a/tests/Integration/app.php
+++ b/tests/Integration/app.php
@@ -5,9 +5,6 @@ namespace GustavPHP\Tests\Integration;
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
-use GustavPHP\Gustav\Auth\Authenticator;
-use GustavPHP\Tests\Integration\Auth\HeaderAuthenticator;
-use GustavPHP\Tests\Integration\Services\{DefaultGreeting, Greeting, RequestState, SingletonState, TransientState};
 
 $configuration = new Configuration(
     mode: Mode::Development,
@@ -17,11 +14,5 @@ $configuration = new Configuration(
 );
 
 $app = new Application(configuration: $configuration);
-$app->services()
-    ->bind(Authenticator::class, HeaderAuthenticator::class)
-    ->bind(Greeting::class, DefaultGreeting::class)
-    ->request(RequestState::class)
-    ->singleton(SingletonState::class)
-    ->transient(TransientState::class);
 
 $app->start();

--- a/tests/Integration/app.php
+++ b/tests/Integration/app.php
@@ -5,6 +5,9 @@ namespace GustavPHP\Tests\Integration;
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Auth\Authenticator;
+use GustavPHP\Tests\Integration\Auth\HeaderAuthenticator;
+use GustavPHP\Tests\Integration\Services\{DefaultGreeting, Greeting, RequestState, SingletonState, TransientState};
 
 $configuration = new Configuration(
     mode: Mode::Development,
@@ -14,5 +17,11 @@ $configuration = new Configuration(
 );
 
 $app = new Application(configuration: $configuration);
+$app->services()
+    ->bind(Authenticator::class, HeaderAuthenticator::class)
+    ->bind(Greeting::class, DefaultGreeting::class)
+    ->request(RequestState::class)
+    ->singleton(SingletonState::class)
+    ->transient(TransientState::class);
 
 $app->start();

--- a/tests/Integration/helpers.php
+++ b/tests/Integration/helpers.php
@@ -3,14 +3,33 @@
 namespace GustavPHP\Tests\Integration;
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Auth\Authenticator;
+use GustavPHP\Tests\Integration\Auth\HeaderAuthenticator;
+use GustavPHP\Tests\Integration\Services\{DefaultGreeting, Greeting, RequestState, SingletonState, TransientState};
 
 function createApplication(Mode $mode = Mode::Production): Application
 {
-    return new Application(new Configuration(
+    $application = new Application(new Configuration(
         mode: $mode,
         namespace: __NAMESPACE__,
         cache: __DIR__ . '/cache/',
     ));
+
+    $application->services()->bind(
+        Authenticator::class,
+        HeaderAuthenticator::class,
+    )->bind(
+        Greeting::class,
+        DefaultGreeting::class,
+    )->request(
+        RequestState::class,
+    )->singleton(
+        SingletonState::class,
+    )->transient(
+        TransientState::class,
+    );
+
+    return $application;
 }
 
 function createClient(): Client

--- a/tests/Integration/helpers.php
+++ b/tests/Integration/helpers.php
@@ -3,33 +3,14 @@
 namespace GustavPHP\Tests\Integration;
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
-use GustavPHP\Gustav\Auth\Authenticator;
-use GustavPHP\Tests\Integration\Auth\HeaderAuthenticator;
-use GustavPHP\Tests\Integration\Services\{DefaultGreeting, Greeting, RequestState, SingletonState, TransientState};
 
 function createApplication(Mode $mode = Mode::Production): Application
 {
-    $application = new Application(new Configuration(
+    return new Application(new Configuration(
         mode: $mode,
         namespace: __NAMESPACE__,
         cache: __DIR__ . '/cache/',
     ));
-
-    $application->services()->bind(
-        Authenticator::class,
-        HeaderAuthenticator::class,
-    )->bind(
-        Greeting::class,
-        DefaultGreeting::class,
-    )->request(
-        RequestState::class,
-    )->singleton(
-        SingletonState::class,
-    )->transient(
-        TransientState::class,
-    );
-
-    return $application;
 }
 
 function createClient(): Client

--- a/tests/Transport/run.php
+++ b/tests/Transport/run.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace GustavPHP\Tests\Transport;
+
+use JsonException;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+const HOST = '127.0.0.1';
+
+/**
+ * @param array<int, int> $excluded
+ */
+function availablePort(array $excluded = []): int
+{
+    do {
+        $errorCode = 0;
+        $errorMessage = '';
+        $socket = @stream_socket_server('tcp://' . HOST . ':0', $errorCode, $errorMessage);
+        if ($socket === false) {
+            throw new RuntimeException("Unable to reserve a local port: {$errorMessage} ({$errorCode})");
+        }
+
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        if ($address === false || !str_contains($address, ':')) {
+            throw new RuntimeException('Unable to determine the reserved local port');
+        }
+        $port = (int) substr($address, strrpos($address, ':') + 1);
+    } while (in_array($port, $excluded, true));
+
+    return $port;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function decodeJson(string $body, string $context): array
+{
+    try {
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $exception) {
+        throw new RuntimeException("{$context} was not valid JSON", previous: $exception);
+    }
+
+    if (!is_array($decoded)) {
+        throw new RuntimeException("{$context} was not a JSON object");
+    }
+
+    return $decoded;
+}
+
+function roadRunnerBinary(string $root): string
+{
+    $filename = PHP_OS_FAMILY === 'Windows' ? 'rr.exe' : 'rr';
+    $binary = $root . DIRECTORY_SEPARATOR . $filename;
+    if (is_file($binary)) {
+        return $binary;
+    }
+
+    echo "RoadRunner binary is missing; downloading it once...\n";
+    $installer = new Process([
+        PHP_BINARY,
+        $root . '/vendor/bin/rr',
+        'get-binary',
+        '--no-config',
+    ], $root);
+    $installer->setTimeout(120);
+    $installer->mustRun();
+
+    if (!is_file($binary)) {
+        throw new RuntimeException("RoadRunner installer did not create {$binary}");
+    }
+
+    return $binary;
+}
+
+/**
+ * @param array<string, string> $headers
+ * @return array{status: int, body: string}
+ */
+function request(
+    int $port,
+    string $method,
+    string $path,
+    ?string $body = null,
+    array $headers = [],
+): array {
+    $headerLines = ['Accept: application/json', 'Connection: close'];
+    foreach ($headers as $name => $value) {
+        $headerLines[] = "{$name}: {$value}";
+    }
+    $options = [
+        'method' => $method,
+        'ignore_errors' => true,
+        'timeout' => 2,
+        'header' => $headerLines,
+    ];
+    if ($body !== null) {
+        $options['content'] = $body;
+    }
+
+    $responseBody = @file_get_contents(
+        'http://' . HOST . ":{$port}{$path}",
+        false,
+        stream_context_create(['http' => $options]),
+    );
+    if (function_exists('http_get_last_response_headers')) {
+        /** @var callable(): null|array<int, string> $getHeaders */
+        $getHeaders = 'http_get_last_response_headers';
+        $responseHeaders = $getHeaders() ?? [];
+    } else {
+        $responseHeaders = $http_response_header ?? [];
+    }
+    if ($responseBody === false || $responseHeaders === []) {
+        throw new RuntimeException("RoadRunner did not respond to {$method} {$path}");
+    }
+    if (!preg_match('/^HTTP\/\S+\s+(\d{3})/', $responseHeaders[0], $matches)) {
+        throw new RuntimeException('RoadRunner returned an invalid HTTP status line');
+    }
+
+    return ['status' => (int) $matches[1], 'body' => $responseBody];
+}
+
+/**
+ * @param array{status: int, body: string} $response
+ */
+function assertStatus(array $response, int $expected, string $context): void
+{
+    if ($response['status'] !== $expected) {
+        throw new RuntimeException(
+            "{$context} returned {$response['status']}; expected {$expected}. Body: {$response['body']}",
+        );
+    }
+}
+
+/**
+ * @return array{request: int, singleton: int}
+ */
+function serviceLifecycle(int $port): array
+{
+    $response = request($port, 'GET', '/services/lifecycle');
+    assertStatus($response, 200, 'Service lifecycle request');
+    $body = decodeJson($response['body'], 'Service lifecycle response');
+    if (
+        ($body['greeting'] ?? null) !== 'configured'
+        || ($body['request'] ?? null) !== ($body['middleware'] ?? null)
+        || ($body['transientsDiffer'] ?? null) !== true
+        || !is_int($body['request'] ?? null)
+        || !is_int($body['singleton'] ?? null)
+    ) {
+        throw new RuntimeException('Service lifecycle response did not satisfy the transport contract');
+    }
+
+    return ['request' => $body['request'], 'singleton' => $body['singleton']];
+}
+
+$root = dirname(__DIR__, 2);
+$server = null;
+$failure = null;
+
+try {
+    $httpPort = availablePort();
+    $rpcPort = availablePort([$httpPort]);
+    $server = new Process([
+        roadRunnerBinary($root),
+        'serve',
+        '-c',
+        '.rr.yaml',
+        '-o',
+        'http.address=' . HOST . ":{$httpPort}",
+        '-o',
+        'rpc.listen=tcp://' . HOST . ":{$rpcPort}",
+    ], $root);
+    $server->setTimeout(null);
+    $server->start();
+
+    $deadline = microtime(true) + 10;
+    do {
+        if (!$server->isRunning()) {
+            throw new RuntimeException('RoadRunner stopped before becoming ready');
+        }
+        try {
+            $ready = request($httpPort, 'GET', '/responses/plaintext');
+        } catch (RuntimeException) {
+            $ready = null;
+        }
+        if ($ready !== null && $ready['status'] === 200 && $ready['body'] === 'lorem ipsum') {
+            break;
+        }
+        usleep(100_000);
+    } while (microtime(true) < $deadline);
+    if ($ready === null || $ready['status'] !== 200 || $ready['body'] !== 'lorem ipsum') {
+        throw new RuntimeException('RoadRunner did not become ready within 10 seconds');
+    }
+
+    $json = request(
+        $httpPort,
+        'POST',
+        '/params/body-dto',
+        '{"email":"ada@example.com","age":"0","active":"false","status":"published","nickname":null}',
+        ['Content-Type' => 'application/json'],
+    );
+    assertStatus($json, 200, 'JSON request');
+    $jsonBody = decodeJson($json['body'], 'JSON response');
+    if (($jsonBody['age'] ?? null) !== 0 || ($jsonBody['active'] ?? null) !== false) {
+        throw new RuntimeException('JSON input was not converted to the declared scalar types');
+    }
+
+    $first = serviceLifecycle($httpPort);
+    assertStatus(request($httpPort, 'GET', '/services/lifecycle/error'), 418, 'Forced service failure');
+    $next = serviceLifecycle($httpPort);
+    if ($first['request'] === $next['request']) {
+        throw new RuntimeException('Request-scoped service was reused after a failed request');
+    }
+    if ($first['singleton'] !== $next['singleton']) {
+        throw new RuntimeException('Singleton service was not preserved by the worker');
+    }
+
+    echo "RoadRunner transport contract passed\n";
+    echo "  JSON request: 200\n";
+    echo "  Worker sequence: 200 -> 418 -> 200\n";
+    echo "  Request scope: {$first['request']} -> {$next['request']}\n";
+    echo "  Singleton: {$first['singleton']} -> {$next['singleton']}\n";
+} catch (Throwable $exception) {
+    $failure = $exception;
+} finally {
+    $server?->stop(5);
+}
+
+if ($failure !== null) {
+    fwrite(STDERR, "RoadRunner transport contract failed: {$failure->getMessage()}\n");
+    if ($server !== null) {
+        $diagnostics = trim($server->getOutput() . $server->getErrorOutput());
+        if ($diagnostics !== '') {
+            fwrite(STDERR, "\nRoadRunner output:\n{$diagnostics}\n");
+        }
+    }
+
+    exit(1);
+}

--- a/tests/Unit/Attribute/MiddlewareTest.php
+++ b/tests/Unit/Attribute/MiddlewareTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use GustavPHP\Gustav\Attribute\Middleware;
+use GustavPHP\Tests\Integration\Middleware\Block;
+
+it('stores an injectable middleware class', function () {
+    $middleware = new Middleware(Block::class);
+
+    expect($middleware->getClass())->toBe(Block::class);
+});
+
+it('rejects classes that are not PSR middleware', function () {
+    new Middleware(stdClass::class);
+})->throws(InvalidArgumentException::class, 'must implement');

--- a/tests/Unit/Attribute/ServiceTest.php
+++ b/tests/Unit/Attribute/ServiceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use GustavPHP\Gustav\Attribute\{GlobalMiddleware, Service};
+use GustavPHP\Gustav\Service\Lifetime;
+use GustavPHP\Tests\Fixtures\Service\ContainerTestContract;
+
+it('describes a discovered service binding and lifetime', function () {
+    $service = new Service(
+        as: ContainerTestContract::class,
+        lifetime: Lifetime::Singleton,
+    );
+
+    expect($service->getService())->toBe(ContainerTestContract::class)
+        ->and($service->getLifetime())->toBe(Lifetime::Singleton);
+});
+
+it('rejects an unknown discovered service abstraction', function () {
+    new Service(as: 'MissingService');
+})->throws(InvalidArgumentException::class, 'does not exist');
+
+it('describes global middleware priority and lifetime', function () {
+    $middleware = new GlobalMiddleware(
+        priority: -100,
+        lifetime: Lifetime::Transient,
+    );
+
+    expect($middleware->getPriority())->toBe(-100)
+        ->and($middleware->getLifetime())->toBe(Lifetime::Transient);
+});

--- a/tests/Unit/Service/ContainerTest.php
+++ b/tests/Unit/Service/ContainerTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use GustavPHP\Gustav\Service\Container;
-use GustavPHP\Tests\Fixtures\Service\{ContainerTestAutowiredController, ContainerTestCircularController, ContainerTestDefinitionController, ContainerTestEmptyController, ContainerTestNestedDependency, ContainerTestPlainDependency, ContainerTestProvidedService, ContainerTestUnresolvableController};
+use GustavPHP\Tests\Fixtures\Service\{ContainerTestAutowiredController, ContainerTestCircularController, ContainerTestContract, ContainerTestDefinitionController, ContainerTestEmptyController, ContainerTestImplementation, ContainerTestInvalidSingleton, ContainerTestInvokableService, ContainerTestNestedDependency, ContainerTestPlainDependency, ContainerTestProvidedService, ContainerTestRequestService, ContainerTestScopedConsumer, ContainerTestSingletonService, ContainerTestTransientService, ContainerTestUnresolvableController};
+use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 it('requires the container to be built before resolving controllers', function () {
     $container = new Container();
@@ -11,11 +13,12 @@ it('requires the container to be built before resolving controllers', function (
 it('autowires nested dependencies and caches resolved services', function () {
     $container = new Container();
     $container->build();
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
 
     /** @var ContainerTestAutowiredController $first */
-    $first = $container->make(ContainerTestAutowiredController::class);
+    $first = $scope->make(ContainerTestAutowiredController::class);
     /** @var ContainerTestAutowiredController $second */
-    $second = $container->make(ContainerTestAutowiredController::class);
+    $second = $scope->make(ContainerTestAutowiredController::class);
 
     expect($first)->toBeInstanceOf(ContainerTestAutowiredController::class);
     expect($first->dependency)->toBeInstanceOf(ContainerTestNestedDependency::class);
@@ -24,50 +27,184 @@ it('autowires nested dependencies and caches resolved services', function () {
     expect($first->dependency->plain)->toBe($second->dependency->plain);
 });
 
-it('uses callable definitions and injects the container into factories when requested', function () {
+it('uses factories and injects the active request container when requested', function () {
     $container = new Container();
     $captured = null;
 
-    $container->addDependency([
-        ContainerTestProvidedService::class => function (Container $current) use (&$captured) {
+    $container->request(
+        ContainerTestProvidedService::class,
+        function (Container $current) use (&$captured) {
             $captured = $current;
             return new ContainerTestProvidedService('custom');
         },
-    ]);
+    );
 
     $container->build();
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
 
     /** @var ContainerTestDefinitionController $controller */
-    $controller = $container->make(ContainerTestDefinitionController::class);
+    $controller = $scope->make(ContainerTestDefinitionController::class);
 
     expect($controller->provided->value)->toBe('custom');
-    expect($captured)->toBe($container);
+    expect($captured)->toBe($scope);
 });
 
 it('rejects invalid dependency identifiers', function () {
     $container = new Container();
-    $container->addDependency([
-        '' => fn () => null,
-    ]);
+    $container->request('', fn () => null);
 })->throws(InvalidArgumentException::class);
 
 it('rejects definitions that are neither callable nor objects', function () {
     $container = new Container();
-    $container->addDependency([
-        'foo' => 'bar',
-    ]);
+    $container->request('foo', 'bar');
 })->throws(InvalidArgumentException::class);
 
 it('detects circular dependencies when instantiating controllers', function () {
     $container = new Container();
     $container->build();
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
 
-    $container->make(ContainerTestCircularController::class);
-})->throws(LogicException::class);
+    $scope->make(ContainerTestCircularController::class);
+})->throws(LogicException::class, 'Circular dependency detected');
 
 it('throws when a constructor parameter cannot be resolved', function () {
     $container = new Container();
     $container->build();
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
 
-    $container->make(ContainerTestUnresolvableController::class);
+    $scope->make(ContainerTestUnresolvableController::class);
 })->throws(InvalidArgumentException::class);
+
+it('binds interfaces to concrete implementations', function () {
+    $container = new Container();
+    $container->bind(ContainerTestContract::class, ContainerTestImplementation::class);
+    $container->build();
+
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+
+    expect($scope->get(ContainerTestContract::class))
+        ->toBeInstanceOf(ContainerTestImplementation::class)
+        ->value()->toBe('implementation');
+});
+
+it('honors singleton, request, and transient lifetimes', function () {
+    $container = new Container();
+    $container
+        ->singleton(ContainerTestSingletonService::class)
+        ->request(ContainerTestRequestService::class)
+        ->transient(ContainerTestTransientService::class);
+    $container->build();
+
+    $first = $container->createRequestScope(new ServerRequest('GET', '/first'));
+    $second = $container->createRequestScope(new ServerRequest('GET', '/second'));
+
+    expect($first->get(ContainerTestSingletonService::class))
+        ->toBe($first->get(ContainerTestSingletonService::class))
+        ->toBe($second->get(ContainerTestSingletonService::class))
+        ->and($first->get(ContainerTestRequestService::class))
+        ->toBe($first->get(ContainerTestRequestService::class))
+        ->not->toBe($second->get(ContainerTestRequestService::class))
+        ->and($first->get(ContainerTestTransientService::class))
+        ->not->toBe($first->get(ContainerTestTransientService::class));
+});
+
+it('injects the current request and isolates autowired services by request', function () {
+    $container = new Container();
+    $container->build();
+
+    $request = new ServerRequest('GET', '/first');
+    $first = $container->createRequestScope($request);
+    $second = $container->createRequestScope(new ServerRequest('GET', '/second'));
+
+    $firstConsumer = $first->get(ContainerTestScopedConsumer::class);
+    $secondConsumer = $second->get(ContainerTestScopedConsumer::class);
+
+    expect($first->has(ServerRequestInterface::class))->toBeTrue()
+        ->and($firstConsumer->request)->toBe($request)
+        ->and($firstConsumer)->toBe($first->get(ContainerTestScopedConsumer::class))
+        ->and($firstConsumer)->not->toBe($secondConsumer)
+        ->and($firstConsumer->service)->not->toBe($secondConsumer->service);
+});
+
+it('prevents singletons from capturing request-scoped services', function () {
+    $container = new Container();
+    $container
+        ->request(ContainerTestRequestService::class)
+        ->singleton(ContainerTestInvalidSingleton::class);
+    $container->build();
+
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope->get(ContainerTestInvalidSingleton::class);
+})->throws(LogicException::class, 'requires an active request scope');
+
+it('freezes registrations after the container is built', function () {
+    $container = new Container();
+    $container->build();
+    $container->singleton(ContainerTestSingletonService::class);
+})->throws(LogicException::class, 'already built');
+
+it('cannot use a released request scope', function () {
+    $container = new Container();
+    $container->build();
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope->release();
+
+    $scope->get(ContainerTestRequestService::class);
+})->throws(LogicException::class, 'released');
+
+it('validates factory signatures during registration', function () {
+    $container = new Container();
+    $container->request('invalid', fn (string $value): string => $value);
+})->throws(InvalidArgumentException::class, Container::class);
+
+it('rejects shared object instances outside the singleton lifetime', function () {
+    $container = new Container();
+    $container->request(
+        ContainerTestProvidedService::class,
+        new ContainerTestProvidedService('shared'),
+    );
+})->throws(InvalidArgumentException::class, 'singleton lifetime');
+
+it('caches null factory results according to their lifetime', function () {
+    $container = new Container();
+    $requestCalls = 0;
+    $singletonCalls = 0;
+    $container
+        ->request('nullable.request', function () use (&$requestCalls) {
+            $requestCalls++;
+            return;
+        })
+        ->singleton('nullable.singleton', function () use (&$singletonCalls) {
+            $singletonCalls++;
+            return;
+        });
+    $container->build();
+
+    $first = $container->createRequestScope(new ServerRequest('GET', '/first'));
+    $second = $container->createRequestScope(new ServerRequest('GET', '/second'));
+
+    $first->get('nullable.request');
+    $first->get('nullable.request');
+    $second->get('nullable.request');
+    $first->get('nullable.singleton');
+    $second->get('nullable.singleton');
+
+    expect($requestCalls)->toBe(2)
+        ->and($singletonCalls)->toBe(1);
+});
+
+it('registers invokable objects as singleton instances instead of factories', function () {
+    $container = new Container();
+    $service = new ContainerTestInvokableService();
+    $container->singleton(ContainerTestInvokableService::class, $service);
+    $container->build();
+
+    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+
+    expect($scope->get(ContainerTestInvokableService::class))->toBe($service);
+});
+
+it('validates singleton object types during registration', function () {
+    $container = new Container();
+    $container->singleton(ContainerTestContract::class, new stdClass());
+})->throws(InvalidArgumentException::class, 'must implement or extend');


### PR DESCRIPTION
## Summary

- add first-class application services with interface bindings, factories, and singleton, request, and transient lifetimes
- discover `#[Service]` classes, service providers, and `#[GlobalMiddleware]` classes from conventional namespaces
- keep the normal application entrypoint free of service, middleware, and route registration calls
- create and reliably release an isolated child container for every HTTP request
- resolve controllers, middleware, and authentication dependencies through the same request scope
- validate definitions early, cache constructor reflection, and report actionable dependency errors
- cover request isolation and worker continuity in-process and through one locally runnable RoadRunner boundary contract

## Canonical application setup

Ordinary applications only construct and start Gustav:

```php
$app = new Application($configuration);
$app->start();
```

Application services are declared where they are implemented:

```php
#[Service(as: ApiKeyVerifier::class)]
final class DatabaseApiKeyVerifier implements ApiKeyVerifier
{
}
```

Gustav recursively discovers attributed classes under the application's `Services` namespace. Concrete request-scoped classes remain autowirable without an attribute. `#[Service]` is needed for an interface binding or a non-default lifetime.

Application-wide middleware is equally declarative:

```php
#[GlobalMiddleware(priority: -100)]
final class RequestIdMiddleware extends Middleware\Base
{
}
```

It is discovered under `Middlewares`; lower priorities run earlier on the request path.

## Design decisions

### Lifetimes and request safety

- `Lifetime::Request` is the default and resolves once in the active request.
- `Lifetime::Singleton` is shared by one application worker.
- `Lifetime::Transient` creates a value on every resolution.

`Application::handle()` creates a child scope and releases it in `finally`, including after middleware or controller failures. Singleton factories resolve against the root container, so they cannot retain a request-scoped dependency from the first RoadRunner request.

### Providers for exceptional construction

Autowired classes cover the normal case. Third-party objects or scalar-driven factories can be registered in a zero-argument class implementing `Service\Provider`. Providers are discovered under `Services` and run during startup, keeping factory configuration out of the entrypoint.

The programmatic registry remains available as an advanced composition and testing API. It freezes when request handling starts.

### Resolution and diagnostics

Factories accept zero arguments or the active `Container`; signatures are compiled during registration. Existing objects are accepted only as singletons. Class and object definitions are checked against class/interface identifiers.

Constructor reflection is cached. Circular resolution reports the dependency chain, null factory results honor their lifetime, and released request scopes cannot be reused.

`Application`, `Configuration`, the active `Container`, and the current `ServerRequestInterface` are injectable framework services.

### Injectable middleware

Middleware attributes carry class metadata rather than constructed objects. Controller, route, and application-wide middleware are resolved through the active service scope, enabling constructor injection without per-request controller reflection.

This intentionally replaces constructed middleware attribute values and the old `Container::addDependency()` API rather than maintaining competing configuration models.

### RoadRunner boundary

The full behavioral suite remains in Pest and runs across PHP 8.2–8.5. The actual RoadRunner boundary is intentionally small and available locally through:

```bash
composer test:transport
```

The command downloads the ignored RoadRunner binary when missing, selects free HTTP and RPC ports, starts one worker, checks one real JSON request plus `200 → 418 → 200` service lifecycle behavior, stops the process, and prints RoadRunner logs on failure.

CI invokes the same command once in a dedicated PHP 8.2 job. It is no longer an inline shell suite duplicated inside every matrix job.

## Verification

- `composer format` — passed
- `composer dump-autoload --optimize --strict-psr` — passed, 4,830 classes
- `composer test` — passed, 142 tests / 396 assertions
- `composer test:transport` — passed
- `composer check` — passed
- `composer lint` — passed
- `composer audit --format=plain` — no advisories
- `composer validate --strict --no-check-publish` — passed
- workflow YAML parse — passed
- `git diff --check` — passed
- starter cross-repository discovery smoke — `GET /api` returned `200 Hello World!` without manual registration

### Transport result

The local command reported:

1. JSON DTO request → `200` with typed scalar conversion
2. `GET /services/lifecycle` → `200`, request service `1`, singleton `1`
3. `GET /services/lifecycle/error` → `418`
4. `GET /services/lifecycle` → `200`, request service `3`, singleton `1`

This verifies the real transport, request-scope cleanup after failure, singleton persistence, and worker continuity without duplicating the full application suite.

## Linked changes

- documentation: gustav-php/gustav-php.github.io#4
- starter: gustav-php/starter#13
