### PR TITLE
Add typed application configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "spiral/roadrunner-cli": "^2.6",
         "spiral/roadrunner-http": "^4.1",
         "symfony/console": "^7.0",
+        "symfony/dotenv": "^7.0",
         "symfony/process": "^7.0"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "356f4bff15bc60f5fa6261134919a3dd",
+    "content-hash": "62bee1837133d5a4511daec8b2143172",
     "packages": [
         {
             "name": "composer/semver",
@@ -1772,6 +1772,84 @@
                 }
             ],
             "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v7.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "99b5b14953237c89ed24f1af5ba34225caf598a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/99b5b14953237c89ed24f1af5ba34225caf598a4",
+                "reference": "99b5b14953237c89ed24f1af5ba34225caf598a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/console": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/dotenv/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-26T10:22:28+00:00"
         },
         {
             "name": "symfony/finder",

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ namespace GustavPHP\Gustav;
 
 use Composer\InstalledVersions;
 use Exception;
+use GustavPHP\Gustav\Config\{Environment, Loader};
 use GustavPHP\Gustav\Controller\{ControllerFactory, Response};
 use GustavPHP\Gustav\Http\Binding\RequestBinder;
 use GustavPHP\Gustav\Http\{CallableRequestHandler, RequestId, ResponseHandler};
@@ -90,6 +91,10 @@ class Application implements RequestHandlerInterface
                     return new ExceptionReporter($logger, $defaultLogger);
                 },
             );
+        $environment = $configuration->getEnvironment() ?? Environment::system();
+        foreach ((new Loader($environment))->load(Discovery::discoverConfigurations()) as $class => $instance) {
+            $this->services->singleton($class, $instance);
+        }
         Router::reset();
         Serializer\Manager::reset();
         Event\Manager::reset();
@@ -234,6 +239,14 @@ class Application implements RequestHandlerInterface
     public static function isProduction(): bool
     {
         return self::$configuration->mode === Mode::Production;
+    }
+
+    /**
+     * Construct and start an application without imperative instance setup.
+     */
+    public static function run(Configuration $configuration): void
+    {
+        (new self($configuration))->start();
     }
 
     /**

--- a/src/Attribute/Config.php
+++ b/src/Attribute/Config.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Config
+{
+}

--- a/src/Attribute/Env.php
+++ b/src/Attribute/Env.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Env
+{
+    public function __construct(public string $name)
+    {
+        if ($name === '' || str_contains($name, '=') || str_contains($name, "\0")) {
+            throw new InvalidArgumentException('Environment variable name is invalid');
+        }
+    }
+}

--- a/src/CLI/DevCommand.php
+++ b/src/CLI/DevCommand.php
@@ -26,12 +26,8 @@ class DevCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $env = realpath(getcwd() . DIRECTORY_SEPARATOR . '.env');
         $roadrunner = realpath(getcwd() . DIRECTORY_SEPARATOR . 'rr');
         $command = "{$roadrunner} serve";
-        if ($env) {
-            $command .= " --dotenv {$env}";
-        }
 
         $latest = $this->getLatestModificationTimestamp();
         $process = Process::fromShellCommandline(escapeshellcmd($command));
@@ -66,6 +62,12 @@ class DevCommand extends Command
     {
         $root = getcwd() . DIRECTORY_SEPARATOR;
         $latest = 0;
+        foreach (['.env', '.env.local'] as $file) {
+            $path = $root . $file;
+            if (is_file($path)) {
+                $latest = max($latest, filemtime($path) ?: 0);
+            }
+        }
         foreach (['src', 'app', 'views'] as $directory) {
             $path = realpath($root . DIRECTORY_SEPARATOR . $directory);
             if (!$path) {

--- a/src/CLI/StartCommand.php
+++ b/src/CLI/StartCommand.php
@@ -19,13 +19,8 @@ class StartCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $env = realpath(getcwd() . DIRECTORY_SEPARATOR . '.env');
         $roadrunner = realpath(getcwd() . DIRECTORY_SEPARATOR . 'rr');
         $command = "{$roadrunner} serve -c ./.rr.prod.yaml";
-
-        if ($env) {
-            $command .= " --dotenv {$env}";
-        }
 
         passthru(escapeshellcmd($command));
 

--- a/src/Config/ConversionFailure.php
+++ b/src/Config/ConversionFailure.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+use RuntimeException;
+
+/** @internal */
+final class ConversionFailure extends RuntimeException
+{
+    public function __construct(
+        public readonly string $violationCode,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/src/Config/Converter.php
+++ b/src/Config/Converter.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+use BackedEnum;
+use JsonException;
+use LogicException;
+use ReflectionEnum;
+use ReflectionNamedType;
+use ReflectionType;
+
+/** @internal */
+final readonly class Converter
+{
+    /**
+     * @param class-string<BackedEnum>|null $enumClass
+     */
+    private function __construct(
+        private string $name,
+        private ?string $enumClass = null,
+        private ?string $enumBackingType = null,
+    ) {
+    }
+
+    public function convert(string $value): mixed
+    {
+        if ($this->enumClass !== null) {
+            return $this->convertEnum($value);
+        }
+
+        return match ($this->name) {
+            'array' => $this->convertArray($value),
+            'bool' => $this->convertBoolean($value),
+            'float' => $this->convertFloat($value),
+            'int' => $this->convertInteger($value),
+            'string' => $value,
+            default => throw new LogicException("Unsupported compiled configuration type {$this->name}"),
+        };
+    }
+
+    public static function fromReflection(?ReflectionType $type, string $location): self
+    {
+        if (!$type instanceof ReflectionNamedType) {
+            throw new LogicException("{$location} must declare one supported named type; ambiguous unions are not supported");
+        }
+
+        $name = $type->getName();
+        if ($type->isBuiltin()) {
+            if (!in_array($name, ['array', 'bool', 'float', 'int', 'string'], true)) {
+                throw new LogicException("{$location} uses unsupported type {$name}");
+            }
+
+            return new self($name);
+        }
+
+        if (enum_exists($name) && is_subclass_of($name, BackedEnum::class)) {
+            /** @var class-string<BackedEnum> $name */
+            $backingType = (new ReflectionEnum($name))->getBackingType()?->getName();
+
+            return new self($name, $name, $backingType);
+        }
+
+        throw new LogicException("{$location} uses unsupported type {$name}");
+    }
+
+    /** @return array<array-key,mixed> */
+    private function convertArray(string $value): array
+    {
+        try {
+            $decoded = json_decode($value, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new ConversionFailure('invalid_array', 'Value must be valid JSON that decodes to an array');
+        }
+
+        if (!is_array($decoded)) {
+            throw new ConversionFailure('invalid_array', 'Value must be valid JSON that decodes to an array');
+        }
+
+        return $decoded;
+    }
+
+    private function convertBoolean(string $value): bool
+    {
+        return match (strtolower($value)) {
+            '1', 'true' => true,
+            '0', 'false' => false,
+            default => throw new ConversionFailure('invalid_boolean', 'Value must be true, false, 1, or 0'),
+        };
+    }
+
+    private function convertEnum(string $value): BackedEnum
+    {
+        $backing = match ($this->enumBackingType) {
+            'int' => $this->integerValue($value),
+            'string' => $value,
+            default => null,
+        };
+
+        if ($backing === null || $this->enumClass === null) {
+            throw new ConversionFailure('invalid_enum', 'Value is not a valid enum case');
+        }
+
+        $case = $this->enumClass::tryFrom($backing);
+        if ($case === null) {
+            throw new ConversionFailure('invalid_enum', 'Value is not a valid enum case');
+        }
+
+        return $case;
+    }
+
+    private function convertFloat(string $value): float
+    {
+        $float = filter_var($value, FILTER_VALIDATE_FLOAT);
+        if ($float === false || !is_finite($float)) {
+            throw new ConversionFailure('invalid_decimal', 'Value must be decimal');
+        }
+
+        return $float;
+    }
+
+    private function convertInteger(string $value): int
+    {
+        $integer = $this->integerValue($value);
+        if ($integer === null) {
+            throw new ConversionFailure('invalid_integer', 'Value must be integer');
+        }
+
+        return $integer;
+    }
+
+    private function integerValue(string $value): ?int
+    {
+        $integer = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $integer === false ? null : $integer;
+    }
+}

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+use InvalidArgumentException;
+use Symfony\Component\Dotenv\Dotenv;
+use Throwable;
+
+final readonly class Environment
+{
+    /**
+     * @param array<string,string> $variables
+     */
+    private function __construct(private array $variables)
+    {
+    }
+
+    /**
+     * Create an isolated environment, primarily for tests.
+     *
+     * @param array<string,string> $variables
+     */
+    public static function fromArray(array $variables): self
+    {
+        foreach ($variables as $name => $value) {
+            if (!is_string($name) || $name === '') {
+                throw new InvalidArgumentException('Environment variable names must be non-empty strings');
+            }
+            if (!is_string($value)) {
+                throw new InvalidArgumentException("Environment variable '{$name}' must be a string");
+            }
+        }
+
+        return new self($variables);
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->variables[$name] ?? null;
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->variables);
+    }
+
+    /**
+     * Load .env and .env.local from a project directory. The optional system
+     * map exists so tests can avoid changing process-global state.
+     *
+     * @param null|array<string,string> $system
+     */
+    public static function load(string $root, ?array $system = null): self
+    {
+        $root = self::normalizeRoot($root);
+        $contents = [];
+        $names = [];
+
+        foreach (['.env', '.env.local'] as $name) {
+            $path = ($root === DIRECTORY_SEPARATOR ? $root : $root . DIRECTORY_SEPARATOR) . $name;
+            if (!file_exists($path)) {
+                continue;
+            }
+            if (!is_file($path) || !is_readable($path)) {
+                throw self::fileException($name, 'Environment file is not readable', 'unreadable_environment_file');
+            }
+            $content = file_get_contents($path);
+            if ($content === false) {
+                throw self::fileException($name, 'Environment file is not readable', 'unreadable_environment_file');
+            }
+            $contents[] = $content;
+            $names[] = $name;
+        }
+
+        $variables = [];
+        if ($contents !== []) {
+            try {
+                /** @var array<string,string> $variables */
+                $variables = (new Dotenv())->parse(
+                    implode("\n", $contents),
+                    implode(', ', $names),
+                );
+            } catch (Throwable) {
+                throw self::fileException(
+                    implode(', ', $names),
+                    'Environment file could not be parsed',
+                    'invalid_environment_file',
+                );
+            }
+        }
+
+        $system ??= self::systemVariables();
+        self::fromArray($system);
+
+        return new self([...$variables, ...$system]);
+    }
+
+    public static function system(): self
+    {
+        return new self(self::systemVariables());
+    }
+
+    private static function fileException(string $name, string $message, string $code): ConfigurationException
+    {
+        return new ConfigurationException([
+            new Violation(
+                configuration: self::class,
+                property: 'file',
+                variable: $name,
+                code: $code,
+                message: $message,
+            ),
+        ]);
+    }
+
+    private static function normalizeRoot(string $root): string
+    {
+        if ($root === '') {
+            throw new InvalidArgumentException('Project root must be a non-empty path');
+        }
+
+        $normalized = rtrim($root, '/\\');
+
+        return $normalized === '' ? DIRECTORY_SEPARATOR : $normalized;
+    }
+
+    /** @return array<string,string> */
+    private static function systemVariables(): array
+    {
+        $variables = [];
+        foreach ($_ENV as $name => $value) {
+            if (is_string($name) && is_string($value)) {
+                $variables[$name] = $value;
+            }
+        }
+
+        $process = getenv();
+        if (is_array($process)) {
+            foreach ($process as $name => $value) {
+                $variables[$name] = $value;
+            }
+        }
+
+        return $variables;
+    }
+}

--- a/src/Config/Exception/ConfigurationException.php
+++ b/src/Config/Exception/ConfigurationException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GustavPHP\Gustav\Config\Exception;
+
+use GustavPHP\Gustav\Config\Violation;
+use InvalidArgumentException;
+use RuntimeException;
+
+final class ConfigurationException extends RuntimeException
+{
+    /**
+     * @param non-empty-list<Violation> $violations
+     */
+    public function __construct(private readonly array $violations)
+    {
+        if ($violations === []) {
+            throw new InvalidArgumentException('Configuration exception requires at least one violation');
+        }
+
+        parent::__construct(
+            "Application configuration is invalid:\n" . implode("\n", array_map(
+                fn (Violation $violation): string => sprintf(
+                    '- %s (%s::$%s): %s',
+                    $violation->variable,
+                    $violation->configuration,
+                    $violation->property,
+                    $violation->message,
+                ),
+                $violations,
+            )),
+        );
+    }
+
+    /** @return non-empty-list<Violation> */
+    public function getViolations(): array
+    {
+        return $this->violations;
+    }
+}

--- a/src/Config/Field.php
+++ b/src/Config/Field.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+use GustavPHP\Gustav\Validation\Validation;
+
+/** @internal */
+final readonly class Field
+{
+    /**
+     * @param list<Validation> $rules
+     */
+    public function __construct(
+        public string $property,
+        public string $variable,
+        public Converter $converter,
+        public bool $hasDefault,
+        public array $rules,
+    ) {
+    }
+}

--- a/src/Config/Hydrator.php
+++ b/src/Config/Hydrator.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+use GustavPHP\Gustav\Attribute\{Config, Env, Validate};
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+use GustavPHP\Gustav\Validation\Validation;
+use LogicException;
+use ReflectionClass;
+use ReflectionParameter;
+use Throwable;
+
+/** @internal */
+final class Hydrator
+{
+    /** @var list<Field> */
+    private array $fields = [];
+
+    /** @var ReflectionClass<object> */
+    private ReflectionClass $reflection;
+
+    /**
+     * @param class-string $className
+     */
+    public function __construct(private readonly string $className)
+    {
+        $this->reflection = new ReflectionClass($className);
+        if ($this->reflection->getAttributes(Config::class) === []) {
+            throw new LogicException("Configuration {$className} must declare #[Config]");
+        }
+        if (!$this->reflection->isReadOnly()) {
+            throw new LogicException("Configuration {$className} must be readonly");
+        }
+        if (!$this->reflection->isInstantiable()) {
+            throw new LogicException("Configuration {$className} must be instantiable");
+        }
+
+        $constructor = $this->reflection->getConstructor();
+        if ($constructor === null) {
+            return;
+        }
+        if (!$constructor->isPublic()) {
+            throw new LogicException("Configuration {$className} must have a public constructor");
+        }
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $this->fields[] = $this->compileField($parameter);
+        }
+    }
+
+    public function hydrate(Environment $environment): object
+    {
+        $values = [];
+        $violations = [];
+
+        foreach ($this->fields as $field) {
+            $raw = $environment->get($field->variable);
+            if ($raw === null) {
+                if (!$field->hasDefault) {
+                    $violations[] = $this->violation($field, 'required', 'Value is required');
+                }
+
+                continue;
+            }
+
+            try {
+                $value = $field->converter->convert($raw);
+            } catch (ConversionFailure $failure) {
+                $violations[] = $this->violation($field, $failure->violationCode, $failure->getMessage());
+
+                continue;
+            }
+
+            foreach ($field->rules as $rule) {
+                $ruleViolation = $rule->getViolation($value);
+                if ($ruleViolation !== null) {
+                    $violations[] = $this->violation(
+                        $field,
+                        $ruleViolation->code,
+                        $ruleViolation->message,
+                    );
+                }
+            }
+
+            $values[$field->property] = $value;
+        }
+
+        if ($violations !== []) {
+            throw new ConfigurationException($violations);
+        }
+
+        try {
+            return $this->reflection->newInstanceArgs($values);
+        } catch (Throwable) {
+            throw new ConfigurationException([
+                new Violation(
+                    configuration: $this->className,
+                    property: 'constructor',
+                    variable: '[constructor]',
+                    code: 'constructor_failed',
+                    message: 'Configuration could not be constructed',
+                ),
+            ]);
+        }
+    }
+
+    private function compileField(ReflectionParameter $parameter): Field
+    {
+        $location = "Configuration constructor parameter {$this->className}::\${$parameter->getName()}";
+        if ($parameter->isVariadic() || $parameter->isPassedByReference()) {
+            throw new LogicException("{$location} cannot be variadic or passed by reference");
+        }
+
+        $attributes = $parameter->getAttributes(Env::class);
+        if (count($attributes) !== 1) {
+            throw new LogicException("{$location} must declare exactly one #[Env] attribute");
+        }
+        $environment = $attributes[0]->newInstance();
+
+        return new Field(
+            property: $parameter->getName(),
+            variable: $environment->name,
+            converter: Converter::fromReflection($parameter->getType(), $location),
+            hasDefault: $parameter->isDefaultValueAvailable(),
+            rules: array_map(
+                function ($attribute): Validation {
+                    /** @var Validate $validation */
+                    $validation = $attribute->newInstance();
+
+                    return $validation->rule;
+                },
+                $parameter->getAttributes(Validate::class),
+            ),
+        );
+    }
+
+    private function violation(Field $field, string $code, string $message): Violation
+    {
+        return new Violation(
+            configuration: $this->className,
+            property: $field->property,
+            variable: $field->variable,
+            code: $code,
+            message: $message,
+        );
+    }
+}

--- a/src/Config/Loader.php
+++ b/src/Config/Loader.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+
+/** @internal */
+final readonly class Loader
+{
+    public function __construct(private Environment $environment)
+    {
+    }
+
+    /**
+     * @param iterable<class-string> $classes
+     * @return array<class-string,object>
+     */
+    public function load(iterable $classes): array
+    {
+        $unique = [];
+        foreach ($classes as $class) {
+            $unique[$class] = true;
+        }
+        $classes = array_keys($unique);
+        sort($classes);
+
+        $configurations = [];
+        $violations = [];
+        foreach ($classes as $class) {
+            try {
+                $configurations[$class] = (new Hydrator($class))->hydrate($this->environment);
+            } catch (ConfigurationException $exception) {
+                array_push($violations, ...$exception->getViolations());
+            }
+        }
+
+        if ($violations !== []) {
+            throw new ConfigurationException($violations);
+        }
+
+        return $configurations;
+    }
+}

--- a/src/Config/Violation.php
+++ b/src/Config/Violation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GustavPHP\Gustav\Config;
+
+final readonly class Violation
+{
+    /**
+     * @param class-string $configuration
+     */
+    public function __construct(
+        public string $configuration,
+        public string $property,
+        public string $variable,
+        public string $code,
+        public string $message,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     configuration:class-string,
+     *     property:string,
+     *     variable:string,
+     *     code:string,
+     *     message:string
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'configuration' => $this->configuration,
+            'property' => $this->property,
+            'variable' => $this->variable,
+            'code' => $this->code,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -2,6 +2,9 @@
 
 namespace GustavPHP\Gustav;
 
+use GustavPHP\Gustav\Config\{Environment, Violation};
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+
 readonly class Configuration
 {
     public function __construct(
@@ -75,6 +78,78 @@ readonly class Configuration
          * @var array<string>
          */
         public array $middlewareNamespaces = [],
+        /**
+         * Namespace containing discoverable typed configuration classes.
+         *
+         * @var array<string>
+         */
+        public array $configurationNamespaces = [],
+        /**
+         * Captured environment used to hydrate typed application configuration.
+         */
+        private ?Environment $environment = null,
     ) {
+    }
+
+    /**
+     * Create a configuration using the conventional project directories and
+     * the MODE value from .env, .env.local, or the real process environment.
+     *
+     * @param array<string> $routeNamespaces
+     * @param array<string> $eventNamespaces
+     * @param array<string> $serializerNamespaces
+     * @param array<string> $serviceNamespaces
+     * @param array<string> $middlewareNamespaces
+     * @param array<string> $configurationNamespaces
+     * @throws ConfigurationException
+     */
+    public static function forProject(
+        string $namespace,
+        string $root,
+        ?Environment $environment = null,
+        array $routeNamespaces = [],
+        array $eventNamespaces = [],
+        array $serializerNamespaces = [],
+        array $serviceNamespaces = [],
+        array $middlewareNamespaces = [],
+        array $configurationNamespaces = [],
+    ): self {
+        $environment ??= Environment::load($root);
+        $mode = match ($environment->get('MODE')) {
+            null, 'development' => Mode::Development,
+            'production' => Mode::Production,
+            default => throw new ConfigurationException([
+                new Violation(
+                    configuration: self::class,
+                    property: 'mode',
+                    variable: 'MODE',
+                    code: 'invalid_mode',
+                    message: 'Value must be development or production',
+                ),
+            ]),
+        };
+        $root = rtrim($root, '/\\');
+        $root = $root === '' ? DIRECTORY_SEPARATOR : $root . DIRECTORY_SEPARATOR;
+
+        return new self(
+            mode: $mode,
+            namespace: $namespace,
+            cache: $root . 'cache' . DIRECTORY_SEPARATOR,
+            files: $root . 'public' . DIRECTORY_SEPARATOR,
+            views: $root . 'views' . DIRECTORY_SEPARATOR,
+            routeNamespaces: $routeNamespaces,
+            eventNamespaces: $eventNamespaces,
+            serializerNamespaces: $serializerNamespaces,
+            serviceNamespaces: $serviceNamespaces,
+            middlewareNamespaces: $middlewareNamespaces,
+            configurationNamespaces: $configurationNamespaces,
+            environment: $environment,
+        );
+    }
+
+    /** @internal */
+    public function getEnvironment(): ?Environment
+    {
+        return $this->environment;
     }
 }

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -12,6 +12,22 @@ use ReflectionClass;
 class Discovery
 {
     /**
+     * @return iterable<class-string>
+     * @throws Exception
+     */
+    public static function discoverConfigurations(): iterable
+    {
+        foreach (self::discoverClasses('Config', 'configurationNamespaces') as $class) {
+            $reflection = new ReflectionClass($class);
+            if ($reflection->getAttributes(Attribute\Config::class) === []) {
+                continue;
+            }
+
+            yield $class;
+        }
+    }
+
+    /**
      * @return iterable<class-string<Controller\Base>>
      * @throws Exception
      */

--- a/tests/ConfigurationFixtures/Unit/AmbiguousConfig.php
+++ b/tests/ConfigurationFixtures/Unit/AmbiguousConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final readonly class AmbiguousConfig
+{
+    public function __construct(
+        #[Env('APP_VALUE')]
+        public string|int $value,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/CompleteConfig.php
+++ b/tests/ConfigurationFixtures/Unit/CompleteConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final readonly class CompleteConfig
+{
+    /**
+     * @param array<mixed> $hosts
+     */
+    public function __construct(
+        #[Env('APP_NAME')]
+        public string $name,
+        #[Env('APP_PORT')]
+        public int $port,
+        #[Env('APP_RATIO')]
+        public float $ratio,
+        #[Env('APP_ENABLED')]
+        public bool $enabled,
+        #[Env('APP_HOSTS')]
+        public array $hosts,
+        #[Env('APP_STAGE')]
+        public Stage $stage,
+        #[Env('APP_PRIORITY')]
+        public Priority $priority,
+        #[Env('APP_NOTE')]
+        public ?string $note = null,
+        #[Env('APP_TIMEOUT')]
+        public int $timeout = 30,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/InvalidScalarConfig.php
+++ b/tests/ConfigurationFixtures/Unit/InvalidScalarConfig.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final readonly class InvalidScalarConfig
+{
+    /** @param array<mixed> $items */
+    public function __construct(
+        #[Env('APP_INTEGER')]
+        public int $integer,
+        #[Env('APP_DECIMAL')]
+        public float $decimal,
+        #[Env('APP_BOOLEAN')]
+        public bool $boolean,
+        #[Env('APP_ITEMS')]
+        public array $items,
+        #[Env('APP_PRIORITY')]
+        public Priority $priority,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/MissingAttributeConfig.php
+++ b/tests/ConfigurationFixtures/Unit/MissingAttributeConfig.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\Config;
+
+#[Config]
+final readonly class MissingAttributeConfig
+{
+    public function __construct(public string $value)
+    {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/MultipleInvalidConfig.php
+++ b/tests/ConfigurationFixtures/Unit/MultipleInvalidConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env, Validate};
+use GustavPHP\Gustav\Validation\Common\{Email, Integer};
+
+#[Config]
+final readonly class MultipleInvalidConfig
+{
+    public function __construct(
+        #[Env('APP_PORT'), Validate(new Integer(min: 1, max: 65535))]
+        public int $port,
+        #[Env('APP_EMAIL'), Validate(new Email())]
+        public string $email,
+        #[Env('APP_STAGE')]
+        public Stage $stage,
+        #[Env('APP_TOKEN')]
+        public string $token,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/MutableConfig.php
+++ b/tests/ConfigurationFixtures/Unit/MutableConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final class MutableConfig
+{
+    public function __construct(
+        #[Env('APP_VALUE')]
+        public string $value,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/OtherInvalidConfig.php
+++ b/tests/ConfigurationFixtures/Unit/OtherInvalidConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final readonly class OtherInvalidConfig
+{
+    public function __construct(
+        #[Env('APP_OTHER')]
+        public string $other,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/Priority.php
+++ b/tests/ConfigurationFixtures/Unit/Priority.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+enum Priority: int
+{
+    case High = 2;
+    case Low = 1;
+}

--- a/tests/ConfigurationFixtures/Unit/RequiredNullableConfig.php
+++ b/tests/ConfigurationFixtures/Unit/RequiredNullableConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final readonly class RequiredNullableConfig
+{
+    public function __construct(
+        #[Env('APP_NOTE')]
+        public ?string $note,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/Unit/Stage.php
+++ b/tests/ConfigurationFixtures/Unit/Stage.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\Unit;
+
+enum Stage: string
+{
+    case Development = 'development';
+    case Production = 'production';
+}

--- a/tests/ConfigurationFixtures/ValidApplication/Config/ApplicationSettings.php
+++ b/tests/ConfigurationFixtures/ValidApplication/Config/ApplicationSettings.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\ValidApplication\Config;
+
+use GustavPHP\Gustav\Attribute\{Config, Env};
+
+#[Config]
+final readonly class ApplicationSettings
+{
+    public function __construct(
+        #[Env('APP_NAME')]
+        public string $name,
+        #[Env('APP_DEBUG')]
+        public bool $debug,
+        #[Env('APP_PORT')]
+        public int $port = 8080,
+    ) {
+    }
+}

--- a/tests/ConfigurationFixtures/ValidApplication/Routes/Settings.php
+++ b/tests/ConfigurationFixtures/ValidApplication/Routes/Settings.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace GustavPHP\Tests\ConfigurationFixtures\ValidApplication\Routes;
+
+use GustavPHP\Gustav\Attribute\Route;
+use GustavPHP\Gustav\Controller;
+use GustavPHP\Tests\ConfigurationFixtures\ValidApplication\Config\ApplicationSettings;
+
+final class Settings extends Controller\Base
+{
+    public function __construct(private readonly ApplicationSettings $settings)
+    {
+    }
+
+    #[Route('/configuration/identity')]
+    public function identity(): int
+    {
+        return spl_object_id($this->settings);
+    }
+
+    /** @return array{name:string,debug:bool,port:int} */
+    #[Route('/configuration')]
+    public function show(): array
+    {
+        return [
+            'name' => $this->settings->name,
+            'debug' => $this->settings->debug,
+            'port' => $this->settings->port,
+        ];
+    }
+}

--- a/tests/Integration/Tests/ConfigurationTest.php
+++ b/tests/Integration/Tests/ConfigurationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Config\Environment;
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+use Nyholm\Psr7\ServerRequest;
+
+function configuredApplication(Environment $environment): Application
+{
+    return new Application(new Configuration(
+        mode: Mode::Production,
+        namespace: 'GustavPHP\\Tests\\ConfigurationFixtures\\ValidApplication',
+        cache: sys_get_temp_dir(),
+        environment: $environment,
+    ));
+}
+
+it('discovers typed configuration and injects it without application bindings', function () {
+    $response = configuredApplication(Environment::fromArray([
+        'APP_NAME' => 'Configured Gustav',
+        'APP_DEBUG' => 'false',
+    ]))->handle(new ServerRequest('GET', '/configuration'));
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and(json_decode((string) $response->getBody(), true))->toBe([
+            'name' => 'Configured Gustav',
+            'debug' => false,
+            'port' => 8080,
+        ]);
+});
+
+it('fails application startup when required configuration is missing', function () {
+    configuredApplication(Environment::fromArray(['APP_DEBUG' => 'true']));
+})->throws(ConfigurationException::class, 'APP_NAME');
+
+it('shares one immutable configuration instance across requests', function () {
+    $application = configuredApplication(Environment::fromArray([
+        'APP_NAME' => 'Configured Gustav',
+        'APP_DEBUG' => 'true',
+    ]));
+
+    $first = $application->handle(new ServerRequest('GET', '/configuration/identity'));
+    $second = $application->handle(new ServerRequest('GET', '/configuration/identity'));
+
+    expect((string) $first->getBody())->toBe((string) $second->getBody());
+});

--- a/tests/Integration/app.php
+++ b/tests/Integration/app.php
@@ -6,13 +6,9 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
 
-$configuration = new Configuration(
+Application::run(new Configuration(
     mode: Mode::Production,
     namespace: __NAMESPACE__,
     cache: __DIR__ . '/cache/',
     files: __DIR__ . '/public/'
-);
-
-$app = new Application(configuration: $configuration);
-
-$app->start();
+));

--- a/tests/Unit/Attribute/ConfigTest.php
+++ b/tests/Unit/Attribute/ConfigTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use GustavPHP\Gustav\Attribute\Env;
+
+it('maps a constructor parameter to an environment variable', function () {
+    expect((new Env('APP_NAME'))->name)->toBe('APP_NAME');
+});
+
+it('rejects invalid environment variable names', function (string $name) {
+    new Env($name);
+})->with(['', 'APP=NAME', "APP\0NAME"])->throws(InvalidArgumentException::class);

--- a/tests/Unit/Config/EnvironmentTest.php
+++ b/tests/Unit/Config/EnvironmentTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use GustavPHP\Gustav\Config\{Environment, Violation};
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+
+function temporaryEnvironmentDirectory(): string
+{
+    $directory = sys_get_temp_dir() . '/gustav-environment-' . bin2hex(random_bytes(8));
+    mkdir($directory, recursive: true);
+
+    return $directory;
+}
+
+function removeEnvironmentDirectory(string $directory): void
+{
+    foreach (['.env.local', '.env'] as $file) {
+        $path = $directory . '/' . $file;
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+    rmdir($directory);
+}
+
+it('loads local dotenv values while preserving real environment variables', function () {
+    $directory = temporaryEnvironmentDirectory();
+    file_put_contents($directory . '/.env', "APP_NAME=base\nAPP_REGION=base\n");
+    file_put_contents($directory . '/.env.local', "APP_NAME=local\nAPP_REGION=local\n");
+
+    try {
+        $environment = Environment::load($directory, system: ['APP_NAME' => 'system']);
+
+        expect($environment->get('APP_NAME'))->toBe('system')
+            ->and($environment->get('APP_REGION'))->toBe('local')
+            ->and($environment->has('MISSING'))->toBeFalse();
+    } finally {
+        removeEnvironmentDirectory($directory);
+    }
+});
+
+it('treats dotenv files as optional', function () {
+    $directory = temporaryEnvironmentDirectory();
+
+    try {
+        expect(Environment::load($directory, system: [])->has('ANYTHING'))->toBeFalse();
+    } finally {
+        removeEnvironmentDirectory($directory);
+    }
+});
+
+it('reports malformed dotenv files without exposing their contents', function () {
+    $directory = temporaryEnvironmentDirectory();
+    file_put_contents($directory . '/.env', "APP_TOKEN=\"super-secret-value\n");
+
+    try {
+        Environment::load($directory, system: []);
+    } catch (ConfigurationException $exception) {
+        expect($exception->getMessage())->toContain('.env')
+            ->not->toContain('super-secret-value')
+            ->and($exception->getViolations())->toHaveCount(1)
+            ->and($exception->getViolations()[0])->toEqual(new Violation(
+                configuration: Environment::class,
+                property: 'file',
+                variable: '.env',
+                code: 'invalid_environment_file',
+                message: 'Environment file could not be parsed',
+            ));
+
+        return;
+    } finally {
+        removeEnvironmentDirectory($directory);
+    }
+
+    throw new RuntimeException('Expected malformed environment file to fail');
+});

--- a/tests/Unit/Config/LoaderTest.php
+++ b/tests/Unit/Config/LoaderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use GustavPHP\Gustav\Config\{Environment, Loader};
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+use GustavPHP\Tests\ConfigurationFixtures\Unit\{AmbiguousConfig, CompleteConfig, InvalidScalarConfig, MissingAttributeConfig, MultipleInvalidConfig, MutableConfig, OtherInvalidConfig, Priority, RequiredNullableConfig, Stage};
+
+it('hydrates every supported configuration type and preserves constructor defaults', function () {
+    $configurations = (new Loader(Environment::fromArray([
+        'APP_NAME' => 'Gustav',
+        'APP_PORT' => '0',
+        'APP_RATIO' => '-0.5',
+        'APP_ENABLED' => 'false',
+        'APP_HOSTS' => '["api.internal","worker.internal"]',
+        'APP_STAGE' => 'production',
+        'APP_PRIORITY' => '2',
+    ])))->load([CompleteConfig::class]);
+
+    expect($configurations[CompleteConfig::class])->toEqual(new CompleteConfig(
+        name: 'Gustav',
+        port: 0,
+        ratio: -0.5,
+        enabled: false,
+        hosts: ['api.internal', 'worker.internal'],
+        stage: Stage::Production,
+        priority: Priority::High,
+    ));
+});
+
+it('reports deterministic violations for every failed conversion', function () {
+    try {
+        (new Loader(Environment::fromArray([
+            'APP_INTEGER' => '1.5',
+            'APP_DECIMAL' => 'infinite',
+            'APP_BOOLEAN' => 'yes',
+            'APP_ITEMS' => 'not-json',
+            'APP_PRIORITY' => '3',
+        ])))->load([InvalidScalarConfig::class]);
+    } catch (ConfigurationException $exception) {
+        expect(array_column(array_map(
+            fn ($violation): array => $violation->toArray(),
+            $exception->getViolations(),
+        ), 'code'))->toBe([
+            'invalid_integer',
+            'invalid_decimal',
+            'invalid_boolean',
+            'invalid_array',
+            'invalid_enum',
+        ]);
+
+        return;
+    }
+
+    throw new RuntimeException('Expected invalid scalar configuration to fail');
+});
+
+it('does not make a nullable constructor parameter optional without a PHP default', function () {
+    (new Loader(Environment::fromArray([])))->load([RequiredNullableConfig::class]);
+})->throws(ConfigurationException::class, 'APP_NOTE');
+
+it('aggregates missing, conversion, enum, and validation failures', function () {
+    try {
+        (new Loader(Environment::fromArray([
+            'APP_PORT' => '0',
+            'APP_EMAIL' => 'super-secret-invalid-email',
+            'APP_STAGE' => 'super-secret-invalid-stage',
+        ])))->load([MultipleInvalidConfig::class, OtherInvalidConfig::class]);
+    } catch (ConfigurationException $exception) {
+        expect($exception->getViolations())->toHaveCount(5)
+            ->and(array_column(array_map(
+                fn ($violation): array => $violation->toArray(),
+                $exception->getViolations(),
+            ), 'code'))->toBe([
+                'min_value',
+                'invalid_email',
+                'invalid_enum',
+                'required',
+                'required',
+            ])
+            ->and($exception->getMessage())->toContain('APP_PORT')
+            ->toContain('APP_EMAIL')
+            ->toContain('APP_STAGE')
+            ->toContain('APP_TOKEN')
+            ->toContain('APP_OTHER')
+            ->not->toContain('super-secret-invalid-email')
+            ->not->toContain('super-secret-invalid-stage');
+
+        return;
+    }
+
+    throw new RuntimeException('Expected invalid configuration to fail');
+});
+
+it('rejects ambiguous configuration types during startup compilation', function () {
+    new Loader(Environment::fromArray(['APP_VALUE' => 'value']))
+        ->load([AmbiguousConfig::class]);
+})->throws(LogicException::class, 'ambiguous unions are not supported');
+
+it('requires immutable configuration classes', function () {
+    new Loader(Environment::fromArray(['APP_VALUE' => 'value']))
+        ->load([MutableConfig::class]);
+})->throws(LogicException::class, 'must be readonly');
+
+it('requires an environment mapping for every constructor parameter', function () {
+    new Loader(Environment::fromArray(['APP_VALUE' => 'value']))
+        ->load([MissingAttributeConfig::class]);
+})->throws(LogicException::class, 'must declare exactly one');

--- a/tests/Unit/Config/LoaderTest.php
+++ b/tests/Unit/Config/LoaderTest.php
@@ -91,16 +91,16 @@ it('aggregates missing, conversion, enum, and validation failures', function () 
 });
 
 it('rejects ambiguous configuration types during startup compilation', function () {
-    new Loader(Environment::fromArray(['APP_VALUE' => 'value']))
+    (new Loader(Environment::fromArray(['APP_VALUE' => 'value'])))
         ->load([AmbiguousConfig::class]);
 })->throws(LogicException::class, 'ambiguous unions are not supported');
 
 it('requires immutable configuration classes', function () {
-    new Loader(Environment::fromArray(['APP_VALUE' => 'value']))
+    (new Loader(Environment::fromArray(['APP_VALUE' => 'value'])))
         ->load([MutableConfig::class]);
 })->throws(LogicException::class, 'must be readonly');
 
 it('requires an environment mapping for every constructor parameter', function () {
-    new Loader(Environment::fromArray(['APP_VALUE' => 'value']))
+    (new Loader(Environment::fromArray(['APP_VALUE' => 'value'])))
         ->load([MissingAttributeConfig::class]);
 })->throws(LogicException::class, 'must declare exactly one');

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use GustavPHP\Gustav\Config\Environment;
+use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+use GustavPHP\Gustav\{Configuration, Mode};
+
+it('builds conventional project paths and mode from a captured environment', function () {
+    $configuration = Configuration::forProject(
+        namespace: 'App',
+        root: '/srv/example',
+        environment: Environment::fromArray(['MODE' => 'production']),
+        configurationNamespaces: ['Module\\Billing\\Config'],
+    );
+
+    expect($configuration->mode)->toBe(Mode::Production)
+        ->and($configuration->namespace)->toBe('App')
+        ->and($configuration->cache)->toBe('/srv/example/cache/')
+        ->and($configuration->files)->toBe('/srv/example/public/')
+        ->and($configuration->views)->toBe('/srv/example/views/')
+        ->and($configuration->configurationNamespaces)->toBe(['Module\\Billing\\Config']);
+});
+
+it('defaults conventional projects to development mode', function () {
+    expect(Configuration::forProject(
+        namespace: 'App',
+        root: '/srv/example/',
+        environment: Environment::fromArray([]),
+    )->mode)->toBe(Mode::Development);
+});
+
+it('rejects invalid modes without exposing the supplied value', function () {
+    try {
+        Configuration::forProject(
+            namespace: 'App',
+            root: '/srv/example',
+            environment: Environment::fromArray(['MODE' => 'super-secret-mode']),
+        );
+    } catch (ConfigurationException $exception) {
+        expect($exception->getMessage())->toContain('MODE')
+            ->not->toContain('super-secret-mode');
+
+        return;
+    }
+
+    throw new RuntimeException('Expected invalid mode to fail');
+});


### PR DESCRIPTION
## Summary

- discover immutable `#[Config]` classes under application `Config` namespaces and register each hydrated object as an application singleton
- map constructor parameters with `#[Env]`, preserving PHP defaults and supporting nullable scalars, JSON arrays, and string- or integer-backed enums
- aggregate missing values, conversion failures, and repeatable `#[Validate]` rule failures into one structured, value-redacted startup exception
- add `Configuration::forProject()` for conventional paths plus `.env` / `.env.local` loading, and `Application::run()` for a bootstrap with no mutable application setup
- centralize dotenv ownership in the framework and watch both environment files during development reloads

## Public API

```php
#[Config]
final readonly class DatabaseConfig
{
    public function __construct(
        #[Env('DATABASE_URL')]
        public string $url,
        #[Env('DATABASE_POOL_SIZE')]
        public int $poolSize = 10,
        #[Env('DATABASE_SSL')]
        public bool $ssl = true,
    ) {
    }
}
```

The class is discovered once at startup and can be constructor-injected directly. No container binding or configuration lookup is required.

## Design decisions

- Configuration objects must be `readonly`; constructor promotion is the canonical style and every constructor parameter requires exactly one environment mapping.
- Missing values without a PHP default are required, including nullable parameters. `?string $value = null` is the explicit optional-null form.
- Boolean conversion accepts only `true`, `false`, `1`, and `0` (case-insensitive). Arrays use JSON. Ambiguous unions and unsupported object types fail during startup compilation rather than guessing.
- Real process variables override `.env.local`, which overrides `.env`. Loading produces one immutable snapshot per worker and does not populate process globals.
- Raw rejected values are never included in framework-generated startup diagnostics. Malformed dotenv parser errors are wrapped without chaining their potentially sensitive message.
- `symfony/dotenv` is a direct dependency because shell-compatible dotenv parsing, quoting, interpolation, and diagnostics are not safe to recreate with a small custom parser; it matches the framework's existing Symfony 7 dependency line.
- The CLI no longer asks RoadRunner to load `.env`; otherwise values injected from the base file would be indistinguishable from real deployment variables and could incorrectly outrank `.env.local`.

## Validation

- `composer format` ✅
- `composer dump-autoload --optimize --strict-psr` ✅ (4,866 classes)
- `composer test` ✅ (188 tests, 527 assertions)
- `composer check` ✅
- `composer lint` ✅
- `composer audit --format=plain` ✅ (no advisories)
- `composer validate --strict --no-check-publish` ✅
- `git diff --check` ✅
- `composer test:transport` ✅
  - JSON request: 200
  - malformed JSON: 400
  - worker recovery: 200 → 418 → 200
  - server failure recovery: 500 → 200 with structured log
  - request scope: 1 → 3
  - singleton: 1 → 1

## Linked follow-ups

- Documentation: gustav-php/gustav-php.github.io#6
- Starter: gustav-php/starter#15
