### PR TITLE
feat: add declarative application commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ After the project has been created, start GustavPHP's local development server u
 php gustav dev
 ```
 
+Application commands are discovered from `src/Commands` and use typed
+arguments, options, validation, and constructor injection. List every built-in
+and project command with:
+
+```bash
+php gustav list
+```
+
 ## Development
 
 Run the fast in-process test suite with:

--- a/bin/gustav-php
+++ b/bin/gustav-php
@@ -2,14 +2,8 @@
 
 <?php
 
-use GustavPHP\Gustav\Application;
-use GustavPHP\Gustav\CLI\{Kernel, ProjectBootstrap};
+use GustavPHP\Gustav\CLI\Kernel;
 
 include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
 
-$configuration = ProjectBootstrap::load();
-$console = $configuration === null
-    ? new Kernel()
-    : (new Application($configuration))->console();
-
-exit($console->run());
+exit(Kernel::forProject()->run());

--- a/bin/gustav-php
+++ b/bin/gustav-php
@@ -2,21 +2,14 @@
 
 <?php
 
-use GustavPHP\Gustav\CLI\{
-    DevCommand,
-    InstalledCommand,
-    StartCommand
-};
-use Symfony\Component\Console\Application;
+use GustavPHP\Gustav\Application;
+use GustavPHP\Gustav\CLI\{Kernel, ProjectBootstrap};
 
 include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
 
-$installed = new InstalledCommand();
-$start = new StartCommand();
-$dev = new DevCommand();
+$configuration = ProjectBootstrap::load();
+$console = $configuration === null
+    ? new Kernel()
+    : (new Application($configuration))->console();
 
-$application = new Application();
-$application->add($dev);
-$application->add($installed);
-$application->add($start);
-$application->run();
+exit($console->run());

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "psr/log": "^3.0",
         "spiral/roadrunner-cli": "^2.6",
         "spiral/roadrunner-http": "^4.1",
-        "symfony/console": "^7.0",
+        "symfony/console": "^7.4",
         "symfony/dotenv": "^7.0",
         "symfony/process": "^7.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62bee1837133d5a4511daec8b2143172",
+    "content-hash": "1b9e1051cb4015567e8054b1df5eeff5",
     "packages": [
         {
             "name": "composer/semver",

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ namespace GustavPHP\Gustav;
 
 use Composer\InstalledVersions;
 use Exception;
+use GustavPHP\Gustav\CLI\{CommandDefinition, Kernel as ConsoleKernel};
 use GustavPHP\Gustav\Config\{Environment, Loader};
 use GustavPHP\Gustav\Controller\{ControllerFactory, Response};
 use GustavPHP\Gustav\Http\Binding\RequestBinder;
@@ -59,6 +60,8 @@ class Application implements RequestHandlerInterface
     protected array $responseHandlers = [];
 
     protected Container $services;
+    /** @var list<CommandDefinition> */
+    private array $commands = [];
 
     private ExceptionReporter $fallbackReporter;
 
@@ -80,7 +83,7 @@ class Application implements RequestHandlerInterface
             ->singleton(Configuration::class, $configuration)
             ->singleton(self::class, $this)
             ->singleton(LoggerInterface::class, $defaultLogger)
-            ->request(
+            ->scoped(
                 ExceptionReporter::class,
                 function (Container $services) use ($defaultLogger): ExceptionReporter {
                     $logger = $services->get(LoggerInterface::class);
@@ -117,6 +120,18 @@ class Application implements RequestHandlerInterface
                 $middleware['lifetime'],
             );
             $this->addMiddleware($middleware['class']);
+        }
+        $commandNames = [];
+        foreach (Discovery::discoverCommands() as $class) {
+            $definition = CommandDefinition::compile($class);
+            if (isset($commandNames[$definition->name])) {
+                throw new LogicException(
+                    "Command name '{$definition->name}' is declared by both "
+                    . "{$commandNames[$definition->name]} and {$class}",
+                );
+            }
+            $commandNames[$definition->name] = $class;
+            $this->commands[] = $definition;
         }
         foreach (Discovery::discoverController() as $class) {
             $this->addRoutes([$class]);
@@ -180,6 +195,16 @@ class Application implements RequestHandlerInterface
     }
 
     /**
+     * Create the application console with all discovered commands.
+     */
+    public function console(): ConsoleKernel
+    {
+        $this->services->build();
+
+        return new ConsoleKernel($this->services, $this->commands, self::$configuration->mode);
+    }
+
+    /**
      * Handle one PSR-7 request independently of the server transport.
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -191,8 +216,9 @@ class Application implements RequestHandlerInterface
 
         try {
             $this->services->build();
-            $scope = $this->services->createRequestScope($request, [
+            $scope = $this->services->createScope([
                 RequestId::class => $requestId,
+                ServerRequestInterface::class => $request,
             ]);
             $path = ltrim($request->getUri()->getPath(), '/');
             $request = $request->withAttribute('Gustav-Path', $path);

--- a/src/Attribute/Argument.php
+++ b/src/Attribute/Argument.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Argument
+{
+    public function __construct(
+        public ?string $name = null,
+        public string $description = '',
+    ) {
+        if ($name !== null && !preg_match('/^[a-z][a-z0-9-]*$/', $name)) {
+            throw new InvalidArgumentException("Command argument name '{$name}' is invalid");
+        }
+    }
+}

--- a/src/Attribute/Command.php
+++ b/src/Attribute/Command.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Command
+{
+    public function __construct(
+        public string $name,
+        public string $description = '',
+        public bool $hidden = false,
+    ) {
+        if (!preg_match('/^[a-z][a-z0-9-]*(?::[a-z][a-z0-9-]*)*$/', $name)) {
+            throw new InvalidArgumentException("Command name '{$name}' is invalid");
+        }
+    }
+}

--- a/src/Attribute/GlobalMiddleware.php
+++ b/src/Attribute/GlobalMiddleware.php
@@ -10,7 +10,7 @@ final readonly class GlobalMiddleware
 {
     public function __construct(
         private int $priority = 0,
-        private Lifetime $lifetime = Lifetime::Request,
+        private Lifetime $lifetime = Lifetime::Scoped,
     ) {
     }
 

--- a/src/Attribute/Option.php
+++ b/src/Attribute/Option.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Option
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $shortcut = null,
+        public string $description = '',
+    ) {
+        if ($name !== null && !preg_match('/^[a-z][a-z0-9-]*$/', $name)) {
+            throw new InvalidArgumentException("Command option name '{$name}' is invalid");
+        }
+        if ($shortcut !== null && !preg_match('/^[a-zA-Z0-9]$/', $shortcut)) {
+            throw new InvalidArgumentException("Command option shortcut '{$shortcut}' is invalid");
+        }
+    }
+}

--- a/src/Attribute/Service.php
+++ b/src/Attribute/Service.php
@@ -14,7 +14,7 @@ final readonly class Service
      */
     public function __construct(
         private ?string $as = null,
-        private Lifetime $lifetime = Lifetime::Request,
+        private Lifetime $lifetime = Lifetime::Scoped,
     ) {
         if (
             $as !== null

--- a/src/CLI/ApplicationCommand.php
+++ b/src/CLI/ApplicationCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use GustavPHP\Gustav\Logger\ExceptionReporter;
+use GustavPHP\Gustav\Mode;
+use GustavPHP\Gustav\Service\Container;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\{InputArgument, InputInterface, InputOption};
+use Symfony\Component\Console\Output\{ConsoleOutputInterface, OutputInterface};
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/** @internal */
+final class ApplicationCommand extends Command
+{
+    private CommandBinder $binder;
+
+    public function __construct(
+        private readonly CommandDefinition $definition,
+        private readonly Container $services,
+        private readonly Mode $mode,
+    ) {
+        $this->binder = new CommandBinder($definition);
+
+        parent::__construct($definition->name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription($this->definition->description);
+        $this->setHidden($this->definition->hidden);
+
+        foreach ($this->definition->parameters as $parameter) {
+            if ($parameter->kind === InputKind::Argument) {
+                $mode = $parameter->hasDefault ? InputArgument::OPTIONAL : InputArgument::REQUIRED;
+                if ($parameter->converter->isArray()) {
+                    $mode |= InputArgument::IS_ARRAY;
+                }
+                $this->addArgument(
+                    $parameter->inputName,
+                    $mode,
+                    $parameter->description,
+                );
+
+                continue;
+            }
+
+            $mode = InputOption::VALUE_REQUIRED;
+            $default = null;
+            if ($parameter->converter->isBoolean()) {
+                if ($parameter->hasDefault && $parameter->defaultValue !== false) {
+                    $mode = InputOption::VALUE_NEGATABLE;
+                    $default = $parameter->defaultValue;
+                } else {
+                    $mode = InputOption::VALUE_NONE;
+                }
+            } elseif ($parameter->converter->isArray()) {
+                $mode |= InputOption::VALUE_IS_ARRAY;
+            }
+
+            $this->addOption(
+                $parameter->inputName,
+                $parameter->shortcut,
+                $mode,
+                $parameter->description,
+                $default,
+            );
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $scope = null;
+
+        try {
+            $scope = $this->services->createScope([
+                InputInterface::class => $input,
+                OutputInterface::class => $output,
+                SymfonyStyle::class => new SymfonyStyle($input, $output),
+            ]);
+            $arguments = $this->binder->bind($input);
+            $handler = $scope->make($this->definition->class);
+            $result = $this->definition->method->invokeArgs($handler, $arguments);
+
+            return $result ?? self::SUCCESS;
+        } catch (CommandInputException $exception) {
+            $this->renderInputFailure($exception, $output);
+
+            return self::INVALID;
+        } catch (Throwable $exception) {
+            $this->reportFailure($exception, $scope);
+            $message = $this->mode === Mode::Production
+                ? 'Command failed'
+                : ($exception->getMessage() ?: $exception::class);
+            $this->errorOutput($output)->writeln(
+                '<error>' . OutputFormatter::escape($message) . '</error>',
+            );
+
+            return self::FAILURE;
+        } finally {
+            $scope?->release();
+        }
+    }
+
+    private function errorOutput(OutputInterface $output): OutputInterface
+    {
+        return $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : $output;
+    }
+
+    private function renderInputFailure(CommandInputException $exception, OutputInterface $output): void
+    {
+        $output = $this->errorOutput($output);
+        $output->writeln('<error>Invalid command input</error>');
+
+        foreach ($exception->violations as $violation) {
+            $location = "{$violation->source} {$violation->path}";
+            $output->writeln(sprintf(
+                '  <comment>%s</comment> [%s] %s',
+                OutputFormatter::escape($location),
+                OutputFormatter::escape($violation->code),
+                OutputFormatter::escape($violation->message),
+            ));
+        }
+    }
+
+    private function reportFailure(Throwable $exception, ?Container $scope): void
+    {
+        if ($scope === null) {
+            return;
+        }
+
+        try {
+            $reporter = $scope->get(ExceptionReporter::class);
+            if ($reporter instanceof ExceptionReporter) {
+                $reporter->reportCommand($exception, $this->definition->name);
+            }
+        } catch (Throwable) {
+            // Reporting failures must not change the command result.
+        }
+    }
+}

--- a/src/CLI/CommandBinder.php
+++ b/src/CLI/CommandBinder.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use GustavPHP\Gustav\Validation\Violation;
+use Symfony\Component\Console\Input\InputInterface;
+
+/** @internal */
+final readonly class CommandBinder
+{
+    public function __construct(private CommandDefinition $definition)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function bind(InputInterface $input): array
+    {
+        $bound = [];
+        $violations = [];
+
+        foreach ($this->definition->parameters as $parameter) {
+            $present = $this->isPresent($input, $parameter);
+            if (!$present) {
+                if (!$parameter->hasDefault) {
+                    $violations[] = new Violation(
+                        $parameter->kind->value,
+                        $this->displayPath($parameter),
+                        'required',
+                        'Value is required',
+                    );
+                }
+
+                continue;
+            }
+
+            $value = $parameter->kind === InputKind::Argument
+                ? $input->getArgument($parameter->inputName)
+                : $input->getOption($parameter->inputName);
+            $result = $parameter->converter->convert(
+                $value,
+                $parameter->kind->value,
+                $this->displayPath($parameter),
+            );
+            if (!$result->isValid) {
+                array_push($violations, ...$result->violations);
+
+                continue;
+            }
+
+            foreach ($parameter->rules as $rule) {
+                $ruleViolation = $rule->getViolation($result->value);
+                if ($ruleViolation !== null) {
+                    $violations[] = new Violation(
+                        $parameter->kind->value,
+                        $this->displayPath($parameter),
+                        $ruleViolation->code,
+                        $ruleViolation->message,
+                    );
+                }
+            }
+
+            $bound[$parameter->parameterName] = $result->value;
+        }
+
+        if ($violations !== []) {
+            throw new CommandInputException($violations);
+        }
+
+        return $bound;
+    }
+
+    private function displayPath(ParameterMetadata $parameter): string
+    {
+        return $parameter->kind === InputKind::Option
+            ? "--{$parameter->inputName}"
+            : $parameter->inputName;
+    }
+
+    private function isPresent(InputInterface $input, ParameterMetadata $parameter): bool
+    {
+        if ($parameter->kind === InputKind::Argument) {
+            $value = $input->getArgument($parameter->inputName);
+
+            return $parameter->converter->isArray() ? $value !== [] : $value !== null;
+        }
+
+        $names = ["--{$parameter->inputName}"];
+        if ($parameter->shortcut !== null) {
+            $names[] = "-{$parameter->shortcut}";
+        }
+        if ($parameter->converter->isBoolean()) {
+            $names[] = "--no-{$parameter->inputName}";
+        }
+
+        return $input->hasParameterOption($names, true);
+    }
+}

--- a/src/CLI/CommandDefinition.php
+++ b/src/CLI/CommandDefinition.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use GustavPHP\Gustav\Attribute\{Argument, Command, Option, Validate};
+use GustavPHP\Gustav\Input\TypeConverter;
+use GustavPHP\Gustav\Validation\Validation;
+use LogicException;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+/** @internal */
+final readonly class CommandDefinition
+{
+    private const RESERVED_OPTION_NAMES = [
+        'ansi',
+        'help',
+        'no-ansi',
+        'no-interaction',
+        'quiet',
+        'verbose',
+        'version',
+    ];
+
+    private const RESERVED_OPTION_SHORTCUTS = ['h', 'n', 'q', 'v', 'V'];
+
+    /**
+     * @param class-string $class
+     * @param list<ParameterMetadata> $parameters
+     */
+    private function __construct(
+        public string $class,
+        public string $name,
+        public string $description,
+        public bool $hidden,
+        public ReflectionMethod $method,
+        public array $parameters,
+    ) {
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function compile(string $class): self
+    {
+        $reflection = new ReflectionClass($class);
+        if (!$reflection->isInstantiable()) {
+            throw new LogicException("Command {$class} must be instantiable");
+        }
+
+        $attributes = $reflection->getAttributes(Command::class);
+        if (count($attributes) !== 1) {
+            throw new LogicException("Command {$class} must declare exactly one " . Command::class . ' attribute');
+        }
+        $command = $attributes[0]->newInstance();
+
+        if (!$reflection->hasMethod('__invoke')) {
+            throw new LogicException("Command {$class} must declare a public __invoke() method");
+        }
+        $method = $reflection->getMethod('__invoke');
+        if (!$method->isPublic() || $method->isStatic()) {
+            throw new LogicException("Command {$class}::__invoke() must be public and non-static");
+        }
+        self::assertReturnType($method, $class);
+
+        $parameters = [];
+        $names = [];
+        $shortcuts = [];
+        $optionalArgumentSeen = false;
+        $arrayArgumentSeen = false;
+
+        foreach ($method->getParameters() as $parameter) {
+            $metadata = self::compileParameter($method, $parameter);
+            $key = $metadata->kind->value . ':' . $metadata->inputName;
+            if (isset($names[$key])) {
+                throw new LogicException(
+                    "Command {$class} declares duplicate {$metadata->kind->value} {$metadata->inputName}",
+                );
+            }
+            $names[$key] = true;
+
+            if ($metadata->shortcut !== null) {
+                if (isset($shortcuts[$metadata->shortcut])) {
+                    throw new LogicException(
+                        "Command {$class} declares duplicate option shortcut {$metadata->shortcut}",
+                    );
+                }
+                $shortcuts[$metadata->shortcut] = true;
+            }
+
+            if ($metadata->kind === InputKind::Argument) {
+                if ($arrayArgumentSeen) {
+                    throw new LogicException("Array argument {$metadata->inputName} must be the final command argument");
+                }
+                if ($optionalArgumentSeen && !$metadata->hasDefault) {
+                    throw new LogicException(
+                        "Required argument {$metadata->inputName} cannot follow an optional command argument",
+                    );
+                }
+                $optionalArgumentSeen = $optionalArgumentSeen || $metadata->hasDefault;
+                $arrayArgumentSeen = $metadata->converter->isArray();
+            }
+
+            $parameters[] = $metadata;
+        }
+
+        return new self(
+            $class,
+            $command->name,
+            $command->description,
+            $command->hidden,
+            $method,
+            $parameters,
+        );
+    }
+
+    private static function assertReturnType(ReflectionMethod $method, string $class): void
+    {
+        $type = $method->getReturnType();
+        if (
+            !$type instanceof ReflectionNamedType
+            || !$type->isBuiltin()
+            || !in_array($type->getName(), ['int', 'void'], true)
+        ) {
+            throw new LogicException("Command {$class}::__invoke() must declare an int or void return type");
+        }
+    }
+
+    private static function compileParameter(
+        ReflectionMethod $method,
+        ReflectionParameter $parameter,
+    ): ParameterMetadata {
+        if ($parameter->isVariadic() || $parameter->isPassedByReference()) {
+            throw new LogicException(
+                "Command parameter {$method->getDeclaringClass()->getName()}::__invoke(\${$parameter->getName()}) cannot be variadic or passed by reference",
+            );
+        }
+
+        $attributes = [
+            ...$parameter->getAttributes(Argument::class),
+            ...$parameter->getAttributes(Option::class),
+        ];
+        $location = "Command parameter {$method->getDeclaringClass()->getName()}::__invoke(\${$parameter->getName()})";
+        if (count($attributes) !== 1) {
+            throw new LogicException("{$location} must declare exactly one command input attribute");
+        }
+
+        $attribute = $attributes[0]->newInstance();
+        $kind = $attribute instanceof Argument ? InputKind::Argument : InputKind::Option;
+        $name = $attribute->name ?? self::kebabCase($parameter->getName());
+        $shortcut = $attribute instanceof Option ? $attribute->shortcut : null;
+
+        $metadata = new ParameterMetadata(
+            $parameter->getName(),
+            $name,
+            $kind,
+            $attribute->description,
+            $shortcut,
+            TypeConverter::fromReflection($parameter->getType(), $location),
+            $parameter->isDefaultValueAvailable(),
+            $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
+            self::rules($parameter),
+        );
+
+        if ($metadata->kind === InputKind::Option) {
+            if (in_array($metadata->inputName, self::RESERVED_OPTION_NAMES, true)) {
+                throw new LogicException("{$location} uses reserved option --{$metadata->inputName}");
+            }
+            if (
+                $metadata->shortcut !== null
+                && in_array($metadata->shortcut, self::RESERVED_OPTION_SHORTCUTS, true)
+            ) {
+                throw new LogicException("{$location} uses reserved option shortcut -{$metadata->shortcut}");
+            }
+            if ($metadata->converter->isBoolean() && !$metadata->hasDefault) {
+                throw new LogicException("{$location} must declare a PHP default for a boolean option");
+            }
+        }
+
+        return $metadata;
+    }
+
+    private static function kebabCase(string $name): string
+    {
+        $converted = preg_replace('/(?<!^)[A-Z]/', '-$0', $name);
+
+        return strtolower($converted ?? $name);
+    }
+
+    /**
+     * @return list<Validation>
+     */
+    private static function rules(ReflectionParameter $parameter): array
+    {
+        return array_map(
+            function (ReflectionAttribute $attribute): Validation {
+                /** @var Validate $validation */
+                $validation = $attribute->newInstance();
+
+                return $validation->rule;
+            },
+            $parameter->getAttributes(Validate::class),
+        );
+    }
+}

--- a/src/CLI/CommandInputException.php
+++ b/src/CLI/CommandInputException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use GustavPHP\Gustav\Validation\Violation;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+
+/** @internal */
+final class CommandInputException extends RuntimeException
+{
+    /**
+     * @param list<Violation> $violations
+     */
+    public function __construct(public readonly array $violations)
+    {
+        if ($violations === []) {
+            throw new InvalidArgumentException('A command input exception requires at least one violation');
+        }
+
+        parent::__construct('Invalid command input', Command::INVALID);
+    }
+}

--- a/src/CLI/DevCommand.php
+++ b/src/CLI/DevCommand.php
@@ -11,11 +11,9 @@ use Symfony\Component\Console\Input\{InputArgument, InputInterface};
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
-#[AsCommand(name: 'dev')]
+#[AsCommand(name: 'dev', description: 'Starts the development server.')]
 class DevCommand extends Command
 {
-    protected static string $defaultDescription = 'Starts development server.';
-
     protected function configure(): void
     {
         $this

--- a/src/CLI/InputKind.php
+++ b/src/CLI/InputKind.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+enum InputKind: string
+{
+    case Argument = 'argument';
+    case Option = 'option';
+}

--- a/src/CLI/InstalledCommand.php
+++ b/src/CLI/InstalledCommand.php
@@ -7,11 +7,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'installed', hidden: true)]
+#[AsCommand(name: 'installed', description: 'Show post-install instructions.', hidden: true)]
 class InstalledCommand extends Command
 {
-    protected static string $defaultDescription = 'Show post install instructions.';
-
     protected function configure(): void
     {
         $this->setHelp('This command is run after installing the starter template..');

--- a/src/CLI/Kernel.php
+++ b/src/CLI/Kernel.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use Composer\InstalledVersions;
+use GustavPHP\Gustav\Mode;
+use GustavPHP\Gustav\Service\Container;
+use LogicException;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException as ConsoleRuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class Kernel extends Application
+{
+    /**
+     * @param list<CommandDefinition> $commands
+     */
+    public function __construct(
+        ?Container $services = null,
+        array $commands = [],
+        Mode $mode = Mode::Development,
+    ) {
+        parent::__construct(
+            'GustavPHP',
+            InstalledVersions::getPrettyVersion('gustav-php/gustav') ?? 'development',
+        );
+        $this->setAutoExit(false);
+        $this->addCommand(new DevCommand());
+        $this->addCommand(new InstalledCommand());
+        $this->addCommand(new StartCommand());
+
+        if ($services === null && $commands !== []) {
+            throw new LogicException('Application commands require an application service container');
+        }
+
+        foreach ($commands as $definition) {
+            if (array_key_exists($definition->name, $this->all())) {
+                throw new LogicException("Command name '{$definition->name}' is already registered");
+            }
+            $this->addCommand(new ApplicationCommand($definition, $services, $mode));
+        }
+    }
+
+    public function doRun(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            return parent::doRun($input, $output);
+        } catch (ConsoleRuntimeException $exception) {
+            throw new \RuntimeException($exception->getMessage(), Command::INVALID);
+        }
+    }
+}

--- a/src/CLI/Kernel.php
+++ b/src/CLI/Kernel.php
@@ -3,16 +3,16 @@
 namespace GustavPHP\Gustav\CLI;
 
 use Composer\InstalledVersions;
-use GustavPHP\Gustav\Mode;
+use GustavPHP\Gustav\{Application, Mode};
 use GustavPHP\Gustav\Service\Container;
 use LogicException;
-use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException as ConsoleRuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class Kernel extends Application
+final class Kernel extends ConsoleApplication
 {
     /**
      * @param list<CommandDefinition> $commands
@@ -50,5 +50,15 @@ final class Kernel extends Application
         } catch (ConsoleRuntimeException $exception) {
             throw new \RuntimeException($exception->getMessage(), Command::INVALID);
         }
+    }
+
+    public static function forProject(?string $root = null): self
+    {
+        $configuration = ProjectBootstrap::load($root);
+        if ($configuration === null) {
+            return new self();
+        }
+
+        return (new Application($configuration))->console();
     }
 }

--- a/src/CLI/ParameterMetadata.php
+++ b/src/CLI/ParameterMetadata.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use GustavPHP\Gustav\Input\TypeConverter;
+use GustavPHP\Gustav\Validation\Validation;
+
+/** @internal */
+final readonly class ParameterMetadata
+{
+    /**
+     * @param list<Validation> $rules
+     */
+    public function __construct(
+        public string $parameterName,
+        public string $inputName,
+        public InputKind $kind,
+        public string $description,
+        public ?string $shortcut,
+        public TypeConverter $converter,
+        public bool $hasDefault,
+        public mixed $defaultValue,
+        public array $rules,
+    ) {
+    }
+}

--- a/src/CLI/ProjectBootstrap.php
+++ b/src/CLI/ProjectBootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace GustavPHP\Gustav\CLI;
+
+use GustavPHP\Gustav\Configuration;
+use LogicException;
+
+final readonly class ProjectBootstrap
+{
+    public static function load(?string $root = null): ?Configuration
+    {
+        $root ??= getcwd() ?: '.';
+        $path = rtrim($root, '/\\') . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $configuration = require $path;
+        if (!$configuration instanceof Configuration) {
+            throw new LogicException("Project bootstrap '{$path}' must return " . Configuration::class);
+        }
+
+        return $configuration;
+    }
+}

--- a/src/CLI/StartCommand.php
+++ b/src/CLI/StartCommand.php
@@ -7,11 +7,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'start')]
+#[AsCommand(name: 'start', description: 'Starts the production server.')]
 class StartCommand extends Command
 {
-    protected static string $defaultDescription = 'Starts production server.';
-
     protected function configure(): void
     {
         $this->setHelp('This command starts the production server.');

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -85,6 +85,12 @@ readonly class Configuration
          */
         public array $configurationNamespaces = [],
         /**
+         * Namespace containing discoverable application commands.
+         *
+         * @var array<string>
+         */
+        public array $commandNamespaces = [],
+        /**
          * Captured environment used to hydrate typed application configuration.
          */
         private ?Environment $environment = null,
@@ -101,6 +107,7 @@ readonly class Configuration
      * @param array<string> $serviceNamespaces
      * @param array<string> $middlewareNamespaces
      * @param array<string> $configurationNamespaces
+     * @param array<string> $commandNamespaces
      * @throws ConfigurationException
      */
     public static function forProject(
@@ -113,6 +120,7 @@ readonly class Configuration
         array $serviceNamespaces = [],
         array $middlewareNamespaces = [],
         array $configurationNamespaces = [],
+        array $commandNamespaces = [],
     ): self {
         $environment ??= Environment::load($root);
         $mode = match ($environment->get('MODE')) {
@@ -143,6 +151,7 @@ readonly class Configuration
             serviceNamespaces: $serviceNamespaces,
             middlewareNamespaces: $middlewareNamespaces,
             configurationNamespaces: $configurationNamespaces,
+            commandNamespaces: $commandNamespaces,
             environment: $environment,
         );
     }

--- a/src/DTO/DtoField.php
+++ b/src/DTO/DtoField.php
@@ -2,7 +2,7 @@
 
 namespace GustavPHP\Gustav\DTO;
 
-use GustavPHP\Gustav\Http\Binding\TypeConverter;
+use GustavPHP\Gustav\Input\TypeConverter;
 use GustavPHP\Gustav\Validation\Validation;
 use ReflectionProperty;
 

--- a/src/DTO/Hydrator.php
+++ b/src/DTO/Hydrator.php
@@ -3,7 +3,7 @@
 namespace GustavPHP\Gustav\DTO;
 
 use GustavPHP\Gustav\Attribute\Validate;
-use GustavPHP\Gustav\Http\Binding\{ConversionResult, TypeConverter};
+use GustavPHP\Gustav\Input\{ConversionResult, TypeConverter};
 use GustavPHP\Gustav\Validation\{Validation, Violation};
 use LogicException;
 use ReflectionClass;

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -15,6 +15,22 @@ class Discovery
      * @return iterable<class-string>
      * @throws Exception
      */
+    public static function discoverCommands(): iterable
+    {
+        foreach (self::discoverClasses('Commands', 'commandNamespaces') as $class) {
+            $reflection = new ReflectionClass($class);
+            if ($reflection->getAttributes(Attribute\Command::class) === []) {
+                continue;
+            }
+
+            yield $class;
+        }
+    }
+
+    /**
+     * @return iterable<class-string>
+     * @throws Exception
+     */
     public static function discoverConfigurations(): iterable
     {
         foreach (self::discoverClasses('Config', 'configurationNamespaces') as $class) {

--- a/src/Http/Binding/ArgumentMetadata.php
+++ b/src/Http/Binding/ArgumentMetadata.php
@@ -3,6 +3,7 @@
 namespace GustavPHP\Gustav\Http\Binding;
 
 use GustavPHP\Gustav\Http\Binding\Resolver\InputResolver;
+use GustavPHP\Gustav\Input\TypeConverter;
 use GustavPHP\Gustav\Validation\Validation;
 
 final readonly class ArgumentMetadata

--- a/src/Http/Binding/RequestBinder.php
+++ b/src/Http/Binding/RequestBinder.php
@@ -6,6 +6,7 @@ use GustavPHP\Gustav\Attribute\{AuthUser, Body, Cookie, Header, Param, Query, Re
 use GustavPHP\Gustav\Auth\Identity;
 use GustavPHP\Gustav\Http\Binding\Resolver\{AuthUserResolver, BodyResolver, CookieResolver, HeaderResolver, InputResolver, ParamResolver, QueryResolver, RequestResolver};
 use GustavPHP\Gustav\Http\Exception\ValidationException;
+use GustavPHP\Gustav\Input\{ConversionResult, TypeConverter};
 use GustavPHP\Gustav\Validation\{Validation, Violation};
 use LogicException;
 use Psr\Http\Message\{ServerRequestInterface};

--- a/src/Input/ConversionResult.php
+++ b/src/Input/ConversionResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GustavPHP\Gustav\Http\Binding;
+namespace GustavPHP\Gustav\Input;
 
 use GustavPHP\Gustav\Validation\Violation;
 

--- a/src/Input/TypeConverter.php
+++ b/src/Input/TypeConverter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GustavPHP\Gustav\Http\Binding;
+namespace GustavPHP\Gustav\Input;
 
 use BackedEnum;
 use GustavPHP\Gustav\DTO\Hydrator;
@@ -91,6 +91,16 @@ final readonly class TypeConverter
 
         /** @var class-string<object> $name */
         return new self($name, $type->allowsNull(), hydrator: new Hydrator($name));
+    }
+
+    public function isArray(): bool
+    {
+        return $this->name === 'array';
+    }
+
+    public function isBoolean(): bool
+    {
+        return $this->name === 'bool';
     }
 
     private function convertBoolean(mixed $value, string $source, string $path): ConversionResult

--- a/src/Logger/ExceptionReporter.php
+++ b/src/Logger/ExceptionReporter.php
@@ -46,4 +46,25 @@ final readonly class ExceptionReporter
             }
         }
     }
+
+    public function reportCommand(Throwable $exception, string $command): void
+    {
+        $context = [
+            'command' => $command,
+            'exception' => $exception,
+        ];
+
+        try {
+            $this->logger->error('Command failed', $context);
+        } catch (Throwable $loggerFailure) {
+            try {
+                $this->fallback->error('Command failed', [
+                    ...$context,
+                    'logger_failure' => $loggerFailure,
+                ]);
+            } catch (Throwable) {
+                // Reporting failures must not alter the command result.
+            }
+        }
+    }
 }

--- a/src/Service/Container.php
+++ b/src/Service/Container.php
@@ -36,7 +36,7 @@ class Container
     public function bind(
         string $id,
         string $implementation,
-        Lifetime $lifetime = Lifetime::Request,
+        Lifetime $lifetime = Lifetime::Scoped,
     ): self {
         if (!class_exists($implementation)) {
             throw new InvalidArgumentException("Service implementation '{$implementation}' does not exist");
@@ -61,11 +61,11 @@ class Container
     }
 
     /**
-     * Create the isolated service scope for one HTTP request.
+     * Create one isolated application execution scope.
      *
      * @param array<string, mixed> $seed
      */
-    public function createRequestScope(ServerRequestInterface $request, array $seed = []): self
+    public function createScope(array $seed = []): self
     {
         $this->assertRoot();
         $this->assertBuilt();
@@ -73,10 +73,7 @@ class Container
         $scope = new self();
         $scope->root = $this;
         $scope->state = $this->state;
-        $scope->resolved = [
-            ...$seed,
-            ServerRequestInterface::class => $request,
-        ];
+        $scope->resolved = $seed;
 
         return $scope;
     }
@@ -101,12 +98,12 @@ class Container
             if (!class_exists($id)) {
                 throw new InvalidArgumentException("Unable to resolve '{$id}'");
             }
-            $definition = new Definition(Lifetime::Request, $id);
+            $definition = new Definition(Lifetime::Scoped, $id);
         }
 
         return match ($definition->lifetime) {
             Lifetime::Singleton => $this->root->resolveSingleton($id, $definition),
-            Lifetime::Request => $this->resolveRequest($id, $definition),
+            Lifetime::Scoped => $this->resolveScoped($id, $definition),
             Lifetime::Transient => $this->create($id, $definition),
         };
     }
@@ -136,7 +133,7 @@ class Container
     }
 
     /**
-     * Release all references owned by this request scope.
+     * Release all references owned by this execution scope.
      */
     public function release(): void
     {
@@ -150,11 +147,12 @@ class Container
     }
 
     /**
-     * Register one service instance per HTTP request.
+     * Register one service instance per HTTP request, console command, or
+     * future application execution boundary.
      */
-    public function request(string $id, mixed $definition = null): self
+    public function scoped(string $id, mixed $definition = null): self
     {
-        return $this->register($id, $definition ?? $id, Lifetime::Request);
+        return $this->register($id, $definition ?? $id, Lifetime::Scoped);
     }
 
     /**
@@ -163,7 +161,7 @@ class Container
      */
     public function setRequest(ServerRequestInterface $request): void
     {
-        $this->assertRequestScope();
+        $this->assertScope();
         $this->assertActive();
         $this->resolved[ServerRequestInterface::class] = $request;
     }
@@ -187,7 +185,7 @@ class Container
     private function assertActive(): void
     {
         if ($this->released) {
-            throw new LogicException('Request service scope has already been released');
+            throw new LogicException('Application service scope has already been released');
         }
     }
 
@@ -198,17 +196,17 @@ class Container
         }
     }
 
-    private function assertRequestScope(): void
-    {
-        if ($this->root === $this) {
-            throw new LogicException('This operation requires an active request scope');
-        }
-    }
-
     private function assertRoot(): void
     {
         if ($this->root !== $this) {
             throw new LogicException('Services can only be registered on the application container');
+        }
+    }
+
+    private function assertScope(): void
+    {
+        if ($this->root === $this) {
+            throw new LogicException('This operation requires an active application scope');
         }
     }
 
@@ -353,10 +351,10 @@ class Container
         );
     }
 
-    private function resolveRequest(string $id, Definition $definition): mixed
+    private function resolveScoped(string $id, Definition $definition): mixed
     {
         if ($this->root === $this) {
-            throw new LogicException("Request-scoped service '{$id}' requires an active request scope");
+            throw new LogicException("Scoped service '{$id}' requires an active application scope");
         }
 
         if (array_key_exists($id, $this->resolved)) {

--- a/src/Service/Lifetime.php
+++ b/src/Service/Lifetime.php
@@ -4,7 +4,7 @@ namespace GustavPHP\Gustav\Service;
 
 enum Lifetime
 {
-    case Request;
+    case Scoped;
     case Singleton;
     case Transient;
 }

--- a/tests/CommandFixtures/DuplicateApplication/Commands/FirstCommand.php
+++ b/tests/CommandFixtures/DuplicateApplication/Commands/FirstCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\DuplicateApplication\Commands;
+
+use GustavPHP\Gustav\Attribute\Command;
+
+#[Command('app:duplicate')]
+final class FirstCommand
+{
+    public function __invoke(): int
+    {
+        return 0;
+    }
+}

--- a/tests/CommandFixtures/DuplicateApplication/Commands/SecondCommand.php
+++ b/tests/CommandFixtures/DuplicateApplication/Commands/SecondCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\DuplicateApplication\Commands;
+
+use GustavPHP\Gustav\Attribute\Command;
+
+#[Command('app:duplicate')]
+final class SecondCommand
+{
+    public function __invoke(): int
+    {
+        return 0;
+    }
+}

--- a/tests/CommandFixtures/InvalidApplication/Commands/InvalidCommand.php
+++ b/tests/CommandFixtures/InvalidApplication/Commands/InvalidCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\InvalidApplication\Commands;
+
+use GustavPHP\Gustav\Attribute\Command;
+
+#[Command('app:invalid')]
+final class InvalidCommand
+{
+    public function __invoke(string $missingInputAttribute): int
+    {
+        return 0;
+    }
+}

--- a/tests/CommandFixtures/InvalidProject/app/bootstrap.php
+++ b/tests/CommandFixtures/InvalidProject/app/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+return new stdClass();

--- a/tests/CommandFixtures/Module/Commands/PingCommand.php
+++ b/tests/CommandFixtures/Module/Commands/PingCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\Module\Commands;
+
+use GustavPHP\Gustav\Attribute\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[Command('module:ping', description: 'Ping a module')]
+final class PingCommand
+{
+    public function __construct(private readonly SymfonyStyle $output)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        $this->output->writeln('pong');
+    }
+}

--- a/tests/CommandFixtures/Project/app/bootstrap.php
+++ b/tests/CommandFixtures/Project/app/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use GustavPHP\Gustav\{Configuration, Mode};
+
+return new Configuration(
+    mode: Mode::Production,
+    namespace: 'GustavPHP\\Tests\\CommandFixtures\\ValidApplication',
+    cache: sys_get_temp_dir(),
+);

--- a/tests/CommandFixtures/Signatures/Commands/RequiredBooleanCommand.php
+++ b/tests/CommandFixtures/Signatures/Commands/RequiredBooleanCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\Signatures\Commands;
+
+use GustavPHP\Gustav\Attribute\{Command, Option};
+
+#[Command('invalid:required-boolean')]
+final class RequiredBooleanCommand
+{
+    public function __invoke(
+        #[Option]
+        bool $force,
+    ): int {
+        return 0;
+    }
+}

--- a/tests/CommandFixtures/Signatures/Commands/ReservedOptionCommand.php
+++ b/tests/CommandFixtures/Signatures/Commands/ReservedOptionCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\Signatures\Commands;
+
+use GustavPHP\Gustav\Attribute\{Command, Option};
+
+#[Command('invalid:reserved-option')]
+final class ReservedOptionCommand
+{
+    public function __invoke(
+        #[Option('help')]
+        string $help = '',
+    ): int {
+        return 0;
+    }
+}

--- a/tests/CommandFixtures/ValidApplication/Commands/GreetCommand.php
+++ b/tests/CommandFixtures/ValidApplication/Commands/GreetCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\ValidApplication\Commands;
+
+use GustavPHP\Gustav\Attribute\{Argument, Command, Option, Validate};
+use GustavPHP\Gustav\Configuration;
+use GustavPHP\Gustav\Validation\Common\{Integer, Text};
+use GustavPHP\Tests\CommandFixtures\ValidApplication\Services\CommandState;
+use Symfony\Component\Console\Command\Command as ExitCode;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[Command('app:greet', description: 'Render a typed greeting')]
+final readonly class GreetCommand
+{
+    public function __construct(
+        private OutputInterface $output,
+        private CommandState $state,
+        private Configuration $configuration,
+    ) {
+    }
+
+    public function __invoke(
+        #[Argument(description: 'Name to greet')]
+        #[Validate(new Text(minLength: 2))]
+        string $name,
+        #[Option(shortcut: 't', description: 'Number of greetings')]
+        #[Validate(new Integer(min: 1, max: 3))]
+        int $times = 1,
+        #[Option('loud', description: 'Use uppercase output')]
+        bool $loud = false,
+        #[Option(description: 'Execution mode')]
+        RunMode $mode = RunMode::Fast,
+        #[Option(description: 'Greeting punctuation')]
+        ?string $punctuation = null,
+        #[Option(description: 'Use colored output')]
+        bool $color = true,
+        #[Option(description: 'Greeting tags')]
+        array $tag = [],
+    ): int {
+        $message = implode(' ', array_fill(0, $times, "Hello {$name}"));
+        if ($loud) {
+            $message = strtoupper($message);
+        }
+
+        $this->output->writeln((string) json_encode([
+            'message' => $message,
+            'mode' => $mode->value,
+            'punctuation' => $punctuation,
+            'color' => $color,
+            'tags' => $tag,
+            'scope' => $this->state->id,
+            'namespace' => $this->configuration->namespace,
+        ], JSON_THROW_ON_ERROR));
+
+        return ExitCode::SUCCESS;
+    }
+}

--- a/tests/CommandFixtures/ValidApplication/Commands/RequiredOptionsCommand.php
+++ b/tests/CommandFixtures/ValidApplication/Commands/RequiredOptionsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\ValidApplication\Commands;
+
+use GustavPHP\Gustav\Attribute\{Command, Option};
+use Symfony\Component\Console\Command\Command as ExitCode;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[Command('app:required-options')]
+final readonly class RequiredOptionsCommand
+{
+    public function __construct(private OutputInterface $output)
+    {
+    }
+
+    public function __invoke(
+        #[Option]
+        int $count,
+        #[Option]
+        RunMode $mode,
+    ): int {
+        $this->output->writeln("{$count}:{$mode->value}");
+
+        return ExitCode::SUCCESS;
+    }
+}

--- a/tests/CommandFixtures/ValidApplication/Commands/RunMode.php
+++ b/tests/CommandFixtures/ValidApplication/Commands/RunMode.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\ValidApplication\Commands;
+
+enum RunMode: string
+{
+    case Fast = 'fast';
+    case Safe = 'safe';
+}

--- a/tests/CommandFixtures/ValidApplication/Commands/ScopeCommand.php
+++ b/tests/CommandFixtures/ValidApplication/Commands/ScopeCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\ValidApplication\Commands;
+
+use GustavPHP\Gustav\Attribute\Command;
+use GustavPHP\Gustav\Service\Container;
+use GustavPHP\Tests\CommandFixtures\ValidApplication\Services\CommandState;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command as ExitCode;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[Command('app:scope')]
+final class ScopeCommand
+{
+    public static ?Container $capturedScope = null;
+
+    public function __construct(
+        private readonly Container $scope,
+        private readonly CommandState $state,
+        private readonly OutputInterface $output,
+    ) {
+    }
+
+    public function __invoke(
+        #[\GustavPHP\Gustav\Attribute\Option]
+        bool $fail = false,
+    ): int {
+        self::$capturedScope = $this->scope;
+        if ($fail) {
+            throw new RuntimeException('secret command failure');
+        }
+
+        $this->output->writeln((string) $this->state->id);
+
+        return ExitCode::SUCCESS;
+    }
+}

--- a/tests/CommandFixtures/ValidApplication/Services/CommandLogger.php
+++ b/tests/CommandFixtures/ValidApplication/Services/CommandLogger.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\ValidApplication\Services;
+
+use GustavPHP\Gustav\Attribute\Service;
+use GustavPHP\Gustav\Service\Lifetime;
+use Psr\Log\{AbstractLogger, LoggerInterface};
+use Stringable;
+
+#[Service(as: LoggerInterface::class, lifetime: Lifetime::Singleton)]
+final class CommandLogger extends AbstractLogger
+{
+    /** @var list<array{level:mixed,message:string,context:array<string,mixed>}> */
+    public static array $records = [];
+
+    /**
+     * @param mixed $level
+     * @param array<string, mixed> $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        self::$records[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    public static function reset(): void
+    {
+        self::$records = [];
+    }
+}

--- a/tests/CommandFixtures/ValidApplication/Services/CommandState.php
+++ b/tests/CommandFixtures/ValidApplication/Services/CommandState.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GustavPHP\Tests\CommandFixtures\ValidApplication\Services;
+
+use GustavPHP\Gustav\Attribute\Service;
+
+#[Service]
+final readonly class CommandState
+{
+    public int $id;
+
+    public function __construct()
+    {
+        static $next = 0;
+
+        $this->id = ++$next;
+    }
+}

--- a/tests/Fixtures/ThrowingLogging/Services/InMemoryFallbackProvider.php
+++ b/tests/Fixtures/ThrowingLogging/Services/InMemoryFallbackProvider.php
@@ -17,7 +17,7 @@ final class InMemoryFallbackProvider implements Provider
         }
 
         $fallback = new JsonLogger($stream);
-        $services->request(
+        $services->scoped(
             ExceptionReporter::class,
             function (Container $scope) use ($fallback): ExceptionReporter {
                 $logger = $scope->get(LoggerInterface::class);

--- a/tests/Unit/Attribute/CommandTest.php
+++ b/tests/Unit/Attribute/CommandTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use GustavPHP\Gustav\Attribute\{Argument, Command, Option};
+
+it('describes commands, arguments, and options', function () {
+    $command = new Command('users:sync', 'Synchronize users', hidden: true);
+    $argument = new Argument('tenant', 'Tenant identifier');
+    $option = new Option('dry-run', 'd', 'Do not persist changes');
+
+    expect($command->name)->toBe('users:sync')
+        ->and($command->description)->toBe('Synchronize users')
+        ->and($command->hidden)->toBeTrue()
+        ->and($argument->name)->toBe('tenant')
+        ->and($option->name)->toBe('dry-run')
+        ->and($option->shortcut)->toBe('d');
+});
+
+it('rejects invalid command metadata', function (Closure $create) {
+    $create();
+})->with([
+    'command name' => fn () => new Command('Invalid Name'),
+    'argument name' => fn () => new Argument('--tenant'),
+    'option name' => fn () => new Option('dry_run'),
+    'option shortcut' => fn () => new Option(shortcut: 'dry'),
+])->throws(InvalidArgumentException::class);

--- a/tests/Unit/Attribute/ServiceTest.php
+++ b/tests/Unit/Attribute/ServiceTest.php
@@ -14,6 +14,11 @@ it('describes a discovered service binding and lifetime', function () {
         ->and($service->getLifetime())->toBe(Lifetime::Singleton);
 });
 
+it('uses execution scope as the default service lifetime', function () {
+    expect((new Service())->getLifetime())->toBe(Lifetime::Scoped)
+        ->and((new GlobalMiddleware())->getLifetime())->toBe(Lifetime::Scoped);
+});
+
 it('rejects an unknown discovered service abstraction', function () {
     new Service(as: 'MissingService');
 })->throws(InvalidArgumentException::class, 'does not exist');

--- a/tests/Unit/CLI/ApplicationCommandsTest.php
+++ b/tests/Unit/CLI/ApplicationCommandsTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\CLI\CommandDefinition;
+use GustavPHP\Tests\CommandFixtures\Signatures\Commands\{RequiredBooleanCommand, ReservedOptionCommand};
+use GustavPHP\Tests\CommandFixtures\ValidApplication\Commands\ScopeCommand;
+use GustavPHP\Tests\CommandFixtures\ValidApplication\Services\{CommandLogger, CommandState};
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+function commandTestApplication(
+    string $namespace = 'GustavPHP\\Tests\\CommandFixtures\\ValidApplication',
+    Mode $mode = Mode::Production,
+): Application {
+    return new Application(new Configuration(
+        mode: $mode,
+        namespace: $namespace,
+        cache: sys_get_temp_dir(),
+    ));
+}
+
+it('discovers commands and binds typed arguments, options, defaults, and enums', function () {
+    $kernel = commandTestApplication()->console();
+    expect($kernel->has('app:greet'))->toBeTrue();
+    $tester = new ApplicationTester($kernel);
+
+    $status = $tester->run([
+        'command' => 'app:greet',
+        'name' => 'Gustav',
+        '--times' => '2',
+        '--loud' => true,
+        '--mode' => 'safe',
+        '--no-color' => true,
+        '--tag' => ['framework', 'typed'],
+    ]);
+
+    expect($status)->toBe(Command::SUCCESS)
+        ->and(json_decode(trim($tester->getDisplay()), true))->toMatchArray([
+            'message' => 'HELLO GUSTAV HELLO GUSTAV',
+            'mode' => 'safe',
+            'punctuation' => null,
+            'color' => false,
+            'tags' => ['framework', 'typed'],
+            'namespace' => 'GustavPHP\\Tests\\CommandFixtures\\ValidApplication',
+        ]);
+
+    $defaulted = new ApplicationTester(commandTestApplication()->console());
+    $defaulted->run(['command' => 'app:greet', 'name' => 'Gustav']);
+
+    expect(json_decode(trim($defaulted->getDisplay()), true))->toMatchArray([
+        'message' => 'Hello Gustav',
+        'mode' => 'fast',
+        'punctuation' => null,
+        'color' => true,
+        'tags' => [],
+    ]);
+});
+
+it('reports invalid scalar and enum options as command input errors', function () {
+    $tester = new ApplicationTester(commandTestApplication()->console());
+
+    $status = $tester->run([
+        'command' => 'app:greet',
+        'name' => 'Gustav',
+        '--times' => 'many',
+        '--mode' => 'reckless',
+    ]);
+
+    expect($status)->toBe(Command::INVALID)
+        ->and($tester->getDisplay())->toContain('invalid_integer')
+        ->toContain('invalid_enum');
+});
+
+it('aggregates scalar, enum, and rule violations without invoking the command', function () {
+    $tester = new ApplicationTester(commandTestApplication()->console());
+
+    $status = $tester->run([
+        'command' => 'app:greet',
+        'name' => 'G',
+        '--times' => '0',
+        '--mode' => 'reckless',
+    ]);
+    $display = $tester->getDisplay();
+
+    expect($status)->toBe(Command::INVALID)
+        ->and($display)->toContain('Invalid command input')
+        ->toContain('argument name')
+        ->toContain('min_length')
+        ->toContain('option --times')
+        ->toContain('min_value')
+        ->toContain('option --mode')
+        ->toContain('invalid_enum');
+});
+
+it('aggregates missing required options', function () {
+    $tester = new ApplicationTester(commandTestApplication()->console());
+
+    $status = $tester->run(['command' => 'app:required-options']);
+
+    expect($status)->toBe(Command::INVALID)
+        ->and($tester->getDisplay())->toContain('option --count')
+        ->toContain('option --mode')
+        ->toContain('required');
+});
+
+it('uses the invalid-input exit code for missing positional arguments', function () {
+    $tester = new ApplicationTester(commandTestApplication()->console());
+
+    $status = $tester->run(['command' => 'app:greet']);
+
+    expect($status)->toBe(Command::INVALID)
+        ->and($tester->getDisplay())->toContain('Not enough arguments')
+        ->toContain('name');
+});
+
+it('isolates and releases command scopes after success and failure', function () {
+    CommandLogger::reset();
+    $kernel = commandTestApplication()->console();
+    $first = new ApplicationTester($kernel);
+    $second = new ApplicationTester($kernel);
+
+    expect($first->run(['command' => 'app:scope']))->toBe(Command::SUCCESS);
+    $firstId = trim($first->getDisplay());
+    $released = ScopeCommand::$capturedScope;
+    expect(fn () => $released?->get(CommandState::class))
+        ->toThrow(LogicException::class, 'released');
+
+    expect($second->run(['command' => 'app:scope']))->toBe(Command::SUCCESS)
+        ->and(trim($second->getDisplay()))->not->toBe($firstId);
+
+    $failed = new ApplicationTester($kernel);
+    expect($failed->run(['command' => 'app:scope', '--fail' => true]))
+        ->toBe(Command::FAILURE)
+        ->and($failed->getDisplay())->toContain('Command failed')
+        ->not->toContain('secret command failure')
+        ->and(CommandLogger::$records)->toHaveCount(1)
+        ->and(CommandLogger::$records[0]['message'])->toBe('Command failed');
+
+    $releasedAfterFailure = ScopeCommand::$capturedScope;
+    expect(fn () => $releasedAfterFailure?->get(CommandState::class))
+        ->toThrow(LogicException::class, 'released');
+
+    $recovered = new ApplicationTester($kernel);
+    expect($recovered->run(['command' => 'app:scope']))->toBe(Command::SUCCESS);
+});
+
+it('shows unexpected command messages during development', function () {
+    $tester = new ApplicationTester(commandTestApplication(mode: Mode::Development)->console());
+
+    expect($tester->run(['command' => 'app:scope', '--fail' => true]))
+        ->toBe(Command::FAILURE)
+        ->and($tester->getDisplay())->toContain('secret command failure');
+});
+
+it('validates command signatures while the application boots', function () {
+    commandTestApplication('GustavPHP\\Tests\\CommandFixtures\\InvalidApplication');
+})->throws(LogicException::class, 'must declare exactly one command input attribute');
+
+it('rejects duplicate discovered command names', function () {
+    commandTestApplication('GustavPHP\\Tests\\CommandFixtures\\DuplicateApplication');
+})->throws(LogicException::class, 'app:duplicate');
+
+it('discovers additional command namespaces and treats void as success', function () {
+    $application = new Application(new Configuration(
+        mode: Mode::Production,
+        namespace: 'GustavPHP\\Tests\\CommandFixtures\\ValidApplication',
+        cache: sys_get_temp_dir(),
+        commandNamespaces: ['GustavPHP\\Tests\\CommandFixtures\\Module\\Commands'],
+    ));
+    $tester = new ApplicationTester($application->console());
+
+    expect($tester->run(['command' => 'module:ping']))->toBe(Command::SUCCESS)
+        ->and($tester->getDisplay())->toContain('pong');
+});
+
+it('rejects boolean options without defaults and reserved console options', function (string $class, string $message) {
+    try {
+        CommandDefinition::compile($class);
+    } catch (LogicException $exception) {
+        expect($exception->getMessage())->toContain($message);
+
+        return;
+    }
+
+    throw new RuntimeException('Expected invalid command signature to fail');
+})->with([
+    'required boolean flag' => [RequiredBooleanCommand::class, 'PHP default'],
+    'reserved option name' => [ReservedOptionCommand::class, 'reserved option --help'],
+]);

--- a/tests/Unit/CLI/ProjectBootstrapTest.php
+++ b/tests/Unit/CLI/ProjectBootstrapTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use GustavPHP\Gustav\CLI\ProjectBootstrap;
+use GustavPHP\Gustav\Configuration;
+
+it('loads a project configuration from the conventional bootstrap file', function () {
+    $configuration = ProjectBootstrap::load(
+        dirname(__DIR__, 2) . '/CommandFixtures/Project',
+    );
+
+    expect($configuration)->toBeInstanceOf(Configuration::class)
+        ->and($configuration?->namespace)
+        ->toBe('GustavPHP\\Tests\\CommandFixtures\\ValidApplication');
+});
+
+it('allows framework tooling to run outside an application project', function () {
+    expect(ProjectBootstrap::load(dirname(__DIR__, 2) . '/CommandFixtures/MissingProject'))
+        ->toBeNull();
+});
+
+it('rejects project bootstrap files that do not return configuration', function () {
+    ProjectBootstrap::load(dirname(__DIR__, 2) . '/CommandFixtures/InvalidProject');
+})->throws(LogicException::class, Configuration::class);

--- a/tests/Unit/CLI/ProjectBootstrapTest.php
+++ b/tests/Unit/CLI/ProjectBootstrapTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GustavPHP\Gustav\CLI\ProjectBootstrap;
+use GustavPHP\Gustav\CLI\{Kernel, ProjectBootstrap};
 use GustavPHP\Gustav\Configuration;
 
 it('loads a project configuration from the conventional bootstrap file', function () {
@@ -16,6 +16,20 @@ it('loads a project configuration from the conventional bootstrap file', functio
 it('allows framework tooling to run outside an application project', function () {
     expect(ProjectBootstrap::load(dirname(__DIR__, 2) . '/CommandFixtures/MissingProject'))
         ->toBeNull();
+});
+
+it('creates a project console with discovered application commands', function () {
+    $console = Kernel::forProject(dirname(__DIR__, 2) . '/CommandFixtures/Project');
+
+    expect($console->has('app:greet'))->toBeTrue()
+        ->and($console->has('dev'))->toBeTrue();
+});
+
+it('creates a tooling console when there is no application bootstrap', function () {
+    $console = Kernel::forProject(dirname(__DIR__, 2) . '/CommandFixtures/MissingProject');
+
+    expect($console->has('dev'))->toBeTrue()
+        ->and($console->has('app:greet'))->toBeFalse();
 });
 
 it('rejects project bootstrap files that do not return configuration', function () {

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -10,6 +10,7 @@ it('builds conventional project paths and mode from a captured environment', fun
         root: '/srv/example',
         environment: Environment::fromArray(['MODE' => 'production']),
         configurationNamespaces: ['Module\\Billing\\Config'],
+        commandNamespaces: ['Module\\Billing\\Commands'],
     );
 
     expect($configuration->mode)->toBe(Mode::Production)
@@ -17,7 +18,8 @@ it('builds conventional project paths and mode from a captured environment', fun
         ->and($configuration->cache)->toBe('/srv/example/cache/')
         ->and($configuration->files)->toBe('/srv/example/public/')
         ->and($configuration->views)->toBe('/srv/example/views/')
-        ->and($configuration->configurationNamespaces)->toBe(['Module\\Billing\\Config']);
+        ->and($configuration->configurationNamespaces)->toBe(['Module\\Billing\\Config'])
+        ->and($configuration->commandNamespaces)->toBe(['Module\\Billing\\Commands']);
 });
 
 it('defaults conventional projects to development mode', function () {

--- a/tests/Unit/Service/ContainerTest.php
+++ b/tests/Unit/Service/ContainerTest.php
@@ -13,7 +13,9 @@ it('requires the container to be built before resolving controllers', function (
 it('autowires nested dependencies and caches resolved services', function () {
     $container = new Container();
     $container->build();
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope([
+        ServerRequestInterface::class => new ServerRequest('GET', '/'),
+    ]);
 
     /** @var ContainerTestAutowiredController $first */
     $first = $scope->make(ContainerTestAutowiredController::class);
@@ -27,11 +29,11 @@ it('autowires nested dependencies and caches resolved services', function () {
     expect($first->dependency->plain)->toBe($second->dependency->plain);
 });
 
-it('uses factories and injects the active request container when requested', function () {
+it('uses factories and injects the active execution scope when requested', function () {
     $container = new Container();
     $captured = null;
 
-    $container->request(
+    $container->scoped(
         ContainerTestProvidedService::class,
         function (Container $current) use (&$captured) {
             $captured = $current;
@@ -40,7 +42,9 @@ it('uses factories and injects the active request container when requested', fun
     );
 
     $container->build();
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope([
+        ServerRequestInterface::class => new ServerRequest('GET', '/'),
+    ]);
 
     /** @var ContainerTestDefinitionController $controller */
     $controller = $scope->make(ContainerTestDefinitionController::class);
@@ -51,18 +55,18 @@ it('uses factories and injects the active request container when requested', fun
 
 it('rejects invalid dependency identifiers', function () {
     $container = new Container();
-    $container->request('', fn () => null);
+    $container->scoped('', fn () => null);
 })->throws(InvalidArgumentException::class);
 
 it('rejects definitions that are neither callable nor objects', function () {
     $container = new Container();
-    $container->request('foo', 'bar');
+    $container->scoped('foo', 'bar');
 })->throws(InvalidArgumentException::class);
 
 it('detects circular dependencies when instantiating controllers', function () {
     $container = new Container();
     $container->build();
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope();
 
     $scope->make(ContainerTestCircularController::class);
 })->throws(LogicException::class, 'Circular dependency detected');
@@ -70,7 +74,7 @@ it('detects circular dependencies when instantiating controllers', function () {
 it('throws when a constructor parameter cannot be resolved', function () {
     $container = new Container();
     $container->build();
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope();
 
     $scope->make(ContainerTestUnresolvableController::class);
 })->throws(InvalidArgumentException::class);
@@ -80,23 +84,23 @@ it('binds interfaces to concrete implementations', function () {
     $container->bind(ContainerTestContract::class, ContainerTestImplementation::class);
     $container->build();
 
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope();
 
     expect($scope->get(ContainerTestContract::class))
         ->toBeInstanceOf(ContainerTestImplementation::class)
         ->value()->toBe('implementation');
 });
 
-it('honors singleton, request, and transient lifetimes', function () {
+it('honors singleton, scoped, and transient lifetimes', function () {
     $container = new Container();
     $container
         ->singleton(ContainerTestSingletonService::class)
-        ->request(ContainerTestRequestService::class)
+        ->scoped(ContainerTestRequestService::class)
         ->transient(ContainerTestTransientService::class);
     $container->build();
 
-    $first = $container->createRequestScope(new ServerRequest('GET', '/first'));
-    $second = $container->createRequestScope(new ServerRequest('GET', '/second'));
+    $first = $container->createScope();
+    $second = $container->createScope();
 
     expect($first->get(ContainerTestSingletonService::class))
         ->toBe($first->get(ContainerTestSingletonService::class))
@@ -113,8 +117,10 @@ it('injects the current request and isolates autowired services by request', fun
     $container->build();
 
     $request = new ServerRequest('GET', '/first');
-    $first = $container->createRequestScope($request);
-    $second = $container->createRequestScope(new ServerRequest('GET', '/second'));
+    $first = $container->createScope([ServerRequestInterface::class => $request]);
+    $second = $container->createScope([
+        ServerRequestInterface::class => new ServerRequest('GET', '/second'),
+    ]);
 
     $firstConsumer = $first->get(ContainerTestScopedConsumer::class);
     $secondConsumer = $second->get(ContainerTestScopedConsumer::class);
@@ -126,12 +132,13 @@ it('injects the current request and isolates autowired services by request', fun
         ->and($firstConsumer->service)->not->toBe($secondConsumer->service);
 });
 
-it('seeds request-scoped values without replacing the active request', function () {
+it('seeds scoped values without replacing the active request', function () {
     $container = new Container();
     $container->build();
     $request = new ServerRequest('GET', '/seeded');
     $seeded = new ContainerTestPlainDependency();
-    $scope = $container->createRequestScope($request, [
+    $scope = $container->createScope([
+        ServerRequestInterface::class => $request,
         ContainerTestPlainDependency::class => $seeded,
     ]);
 
@@ -139,16 +146,16 @@ it('seeds request-scoped values without replacing the active request', function 
         ->and($scope->get(ServerRequestInterface::class))->toBe($request);
 });
 
-it('prevents singletons from capturing request-scoped services', function () {
+it('prevents singletons from capturing scoped services', function () {
     $container = new Container();
     $container
-        ->request(ContainerTestRequestService::class)
+        ->scoped(ContainerTestRequestService::class)
         ->singleton(ContainerTestInvalidSingleton::class);
     $container->build();
 
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope();
     $scope->get(ContainerTestInvalidSingleton::class);
-})->throws(LogicException::class, 'requires an active request scope');
+})->throws(LogicException::class, 'requires an active application scope');
 
 it('freezes registrations after the container is built', function () {
     $container = new Container();
@@ -156,10 +163,10 @@ it('freezes registrations after the container is built', function () {
     $container->singleton(ContainerTestSingletonService::class);
 })->throws(LogicException::class, 'already built');
 
-it('cannot use a released request scope', function () {
+it('cannot use a released execution scope', function () {
     $container = new Container();
     $container->build();
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope();
     $scope->release();
 
     $scope->get(ContainerTestRequestService::class);
@@ -167,12 +174,12 @@ it('cannot use a released request scope', function () {
 
 it('validates factory signatures during registration', function () {
     $container = new Container();
-    $container->request('invalid', fn (string $value): string => $value);
+    $container->scoped('invalid', fn (string $value): string => $value);
 })->throws(InvalidArgumentException::class, Container::class);
 
 it('rejects shared object instances outside the singleton lifetime', function () {
     $container = new Container();
-    $container->request(
+    $container->scoped(
         ContainerTestProvidedService::class,
         new ContainerTestProvidedService('shared'),
     );
@@ -180,11 +187,11 @@ it('rejects shared object instances outside the singleton lifetime', function ()
 
 it('caches null factory results according to their lifetime', function () {
     $container = new Container();
-    $requestCalls = 0;
+    $scopedCalls = 0;
     $singletonCalls = 0;
     $container
-        ->request('nullable.request', function () use (&$requestCalls) {
-            $requestCalls++;
+        ->scoped('nullable.scoped', function () use (&$scopedCalls) {
+            $scopedCalls++;
             return;
         })
         ->singleton('nullable.singleton', function () use (&$singletonCalls) {
@@ -193,16 +200,16 @@ it('caches null factory results according to their lifetime', function () {
         });
     $container->build();
 
-    $first = $container->createRequestScope(new ServerRequest('GET', '/first'));
-    $second = $container->createRequestScope(new ServerRequest('GET', '/second'));
+    $first = $container->createScope();
+    $second = $container->createScope();
 
-    $first->get('nullable.request');
-    $first->get('nullable.request');
-    $second->get('nullable.request');
+    $first->get('nullable.scoped');
+    $first->get('nullable.scoped');
+    $second->get('nullable.scoped');
     $first->get('nullable.singleton');
     $second->get('nullable.singleton');
 
-    expect($requestCalls)->toBe(2)
+    expect($scopedCalls)->toBe(2)
         ->and($singletonCalls)->toBe(1);
 });
 
@@ -212,7 +219,7 @@ it('registers invokable objects as singleton instances instead of factories', fu
     $container->singleton(ContainerTestInvokableService::class, $service);
     $container->build();
 
-    $scope = $container->createRequestScope(new ServerRequest('GET', '/'));
+    $scope = $container->createScope();
 
     expect($scope->get(ContainerTestInvokableService::class))->toBe($service);
 });


### PR DESCRIPTION
## Summary

- discover plain invokable command classes recursively from the application Commands namespace
- bind typed arguments and options with defaults, nullable values, arrays, booleans, backed enums, and repeatable validation rules
- inject services, typed configuration, console input/output, and SymfonyStyle into command constructors
- isolate every invocation in an execution scope that is released after success, invalid input, or unexpected failure
- load one conventional app/bootstrap.php for both HTTP and CLI entrypoints
- add production-safe command failures, structured logging, stable exit codes, and in-process testing support

## Design decisions

- Command classes stay framework-base-free and use #[Command], #[Argument], and #[Option] only as metadata.
- Symfony Console remains the transport and help/completion layer; Gustav compiles command metadata once during application boot.
- The existing scalar and enum converter moved from Http Binding to a shared Input namespace so HTTP and CLI cannot drift.
- Lifetime::Request and Container::request() become the transport-neutral Lifetime::Scoped and Container::scoped(). A scope now represents one HTTP request or one console invocation.
- Boolean options require PHP defaults: false creates a normal flag, while true also enables the negated --no-* form.
- Validation failures aggregate and exit with 2. Unexpected failures exit with 1, are logged with command context, and expose details only in development.
- Database migrations, queues, scheduling, code generation, and persistence remain outside this PR.

## Validation

- composer format — passed
- composer dump-autoload --optimize --strict-psr — passed; 4,889 classes
- composer test — passed; 209 tests, 610 assertions
- composer check — passed; PHPStan level 8
- composer lint — passed
- composer audit --format=plain — passed; no advisories
- composer validate --strict --no-check-publish — passed
- git diff --check — passed
- direct CLI smoke — valid command exited 0; aggregated invalid input exited 2; list/help discovery passed
- starter integration smoke against this checkout — valid joke command exited 0; invalid validation input exited 2
- composer test:transport — passed: JSON 200, malformed JSON 400, worker sequence 200 -> 418 -> 200, server failure 500 -> 200, scoped service changed, singleton remained stable

## Downstream

- Starter: https://github.com/gustav-php/starter/pull/16
- Documentation: https://github.com/gustav-php/gustav-php.github.io/pull/7