### PR TITLE
Add first-class sessions, flash data, and CSRF protection

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -12,7 +12,9 @@ use GustavPHP\Gustav\Http\Exception\{HttpException, RequestInputException, Valid
 use GustavPHP\Gustav\Logger\{ExceptionReporter, JsonLogger};
 use GustavPHP\Gustav\Middleware\Pipeline;
 use GustavPHP\Gustav\Router\{Method, RouteCompiler, RouteMatch, Router, UrlGeneratorInterface};
+use GustavPHP\Gustav\Security\{CsrfMiddleware, CsrfTokenManager};
 use GustavPHP\Gustav\Service\Container;
+use GustavPHP\Gustav\Session\{FileSessionStore, SessionMiddleware, SessionOptions, SessionStoreInterface};
 use GustavPHP\Gustav\View\{PhpViewRenderer, ViewRendererInterface};
 use InvalidArgumentException;
 use LogicException;
@@ -55,6 +57,8 @@ class Application implements RequestHandlerInterface
 
     private Router $router;
 
+    private bool $sessionsEnabled;
+
     /**
      * Creates a new application instance.
      *
@@ -74,6 +78,16 @@ class Application implements RequestHandlerInterface
         $routes = [];
         foreach (Discovery::discoverControllers() as $class) {
             array_push($routes, ...RouteCompiler::compile($class));
+        }
+        $this->sessionsEnabled = $configuration->session !== null;
+        if (!$this->sessionsEnabled) {
+            foreach ($routes as $route) {
+                if ($route->csrfProtected) {
+                    throw new LogicException(
+                        "CSRF-protected route {$route->location()} requires session configuration",
+                    );
+                }
+            }
         }
         $this->router = new Router($routes);
         $this->services = new Container();
@@ -106,6 +120,15 @@ class Application implements RequestHandlerInterface
                 EventDispatcherInterface::class,
                 Event\Dispatcher::class,
             );
+        if ($configuration->session !== null) {
+            $this->services
+                ->singleton(SessionOptions::class, $configuration->session)
+                ->singleton(SessionStoreInterface::class, FileSessionStore::class)
+                ->scoped(Session::class)
+                ->scoped(SessionMiddleware::class)
+                ->scoped(CsrfTokenManager::class)
+                ->scoped(CsrfMiddleware::class);
+        }
         $environment = $configuration->getEnvironment() ?? Environment::system();
         foreach ((new Loader($environment))->load(Discovery::discoverConfigurations()) as $class => $instance) {
             $this->services->singleton($class, $instance);
@@ -212,8 +235,13 @@ class Application implements RequestHandlerInterface
             $request = $request->withAttribute('Gustav-Path', $path);
             $scope->setRequest($request);
 
+            $middlewares = $this->resolveMiddlewares($this->middlewares, $scope);
+            if ($this->sessionsEnabled) {
+                array_unshift($middlewares, $this->resolveSessionMiddleware($scope));
+            }
+
             $response = (new Pipeline(
-                $this->resolveMiddlewares($this->middlewares, $scope),
+                $middlewares,
                 new CallableRequestHandler(
                     function (ServerRequestInterface $nextRequest) use (
                         $scope,
@@ -391,6 +419,9 @@ class Application implements RequestHandlerInterface
 
         $match = $this->router->match($method, $path);
         $middlewares = $this->resolveMiddlewares($match->route->middlewares, $scope);
+        if ($match->route->csrfProtected) {
+            array_unshift($middlewares, $this->resolveCsrfMiddleware($scope));
+        }
         $request = $request
             ->withAttribute('Gustav-Route', $match->route)
             ->withAttribute('Gustav-Route-Parameters', $match->parameters);
@@ -576,6 +607,16 @@ class Application implements RequestHandlerInterface
         }
     }
 
+    private function resolveCsrfMiddleware(Container $scope): CsrfMiddleware
+    {
+        $middleware = $scope->get(CsrfMiddleware::class);
+        if (!$middleware instanceof CsrfMiddleware) {
+            throw new LogicException('CSRF middleware service is invalid');
+        }
+
+        return $middleware;
+    }
+
     /**
      * @param array<class-string<MiddlewareInterface>> $classes
      * @return array<MiddlewareInterface>
@@ -592,5 +633,15 @@ class Application implements RequestHandlerInterface
 
             return $middleware;
         }, $classes);
+    }
+
+    private function resolveSessionMiddleware(Container $scope): SessionMiddleware
+    {
+        $middleware = $scope->get(SessionMiddleware::class);
+        if (!$middleware instanceof SessionMiddleware) {
+            throw new LogicException('Session middleware service is invalid');
+        }
+
+        return $middleware;
     }
 }

--- a/src/Attribute/Csrf.php
+++ b/src/Attribute/Csrf.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GustavPHP\Gustav\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+final readonly class Csrf
+{
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -4,6 +4,7 @@ namespace GustavPHP\Gustav;
 
 use GustavPHP\Gustav\Config\{Environment, Violation};
 use GustavPHP\Gustav\Config\Exception\ConfigurationException;
+use GustavPHP\Gustav\Session\SessionOptions;
 
 readonly class Configuration
 {
@@ -88,6 +89,10 @@ readonly class Configuration
          * Captured environment used to hydrate typed application configuration.
          */
         private ?Environment $environment = null,
+        /**
+         * Server-side session configuration, or null to disable sessions.
+         */
+        public ?SessionOptions $session = null,
     ) {
     }
 
@@ -102,6 +107,7 @@ readonly class Configuration
      * @param array<string> $middlewareNamespaces
      * @param array<string> $configurationNamespaces
      * @param array<string> $commandNamespaces
+     * @param null|SessionOptions $session
      * @throws ConfigurationException
      */
     public static function forProject(
@@ -115,6 +121,7 @@ readonly class Configuration
         array $middlewareNamespaces = [],
         array $configurationNamespaces = [],
         array $commandNamespaces = [],
+        ?SessionOptions $session = null,
     ): self {
         $environment ??= Environment::load($root);
         $mode = match ($environment->get('MODE')) {
@@ -145,6 +152,9 @@ readonly class Configuration
             middlewareNamespaces: $middlewareNamespaces,
             configurationNamespaces: $configurationNamespaces,
             commandNamespaces: $commandNamespaces,
+            session: $session ?? new SessionOptions(
+                directory: $root . 'storage' . DIRECTORY_SEPARATOR . 'sessions' . DIRECTORY_SEPARATOR,
+            ),
             environment: $environment,
         );
     }

--- a/src/Http/Exception/CsrfException.php
+++ b/src/Http/Exception/CsrfException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GustavPHP\Gustav\Http\Exception;
+
+final class CsrfException extends RequestInputException
+{
+    public function __construct()
+    {
+        parent::__construct(403, 'CSRF token is invalid');
+    }
+}

--- a/src/Router/Method.php
+++ b/src/Router/Method.php
@@ -26,4 +26,15 @@ enum Method: string
     {
         return Method::from($request->getMethod());
     }
+
+    /**
+     * Whether this method is defined as safe by HTTP semantics.
+     */
+    public function isSafe(): bool
+    {
+        return match ($this) {
+            self::GET, self::HEAD, self::OPTIONS, self::TRACE => true,
+            default => false,
+        };
+    }
 }

--- a/src/Router/RouteCompiler.php
+++ b/src/Router/RouteCompiler.php
@@ -2,7 +2,7 @@
 
 namespace GustavPHP\Gustav\Router;
 
-use GustavPHP\Gustav\Attribute\{Controller, Middleware, Route};
+use GustavPHP\Gustav\Attribute\{Controller, Csrf, Middleware, Route};
 use GustavPHP\Gustav\Http\Binding\RequestBinder;
 use GustavPHP\Gustav\Http\ResponseHandler;
 use LogicException;
@@ -31,6 +31,10 @@ final class RouteCompiler
         }
         $controller = $controllerAttributes[0]->newInstance();
         $controllerMiddlewares = self::middlewares($reflection->getAttributes(Middleware::class));
+        $controllerCsrf = self::csrf(
+            $reflection->getAttributes(Csrf::class),
+            "Controller '{$class}'",
+        );
         $definitions = [];
 
         foreach ($reflection->getMethods() as $method) {
@@ -43,6 +47,11 @@ final class RouteCompiler
                 ...$controllerMiddlewares,
                 ...self::middlewares($method->getAttributes(Middleware::class)),
             ];
+            $methodCsrf = self::csrf(
+                $method->getAttributes(Csrf::class),
+                "Controller method {$class}::{$method->getName()}()",
+            );
+            $csrf = $controllerCsrf || $methodCsrf;
 
             foreach ($routes as $routeAttribute) {
                 $route = $routeAttribute->newInstance();
@@ -56,6 +65,7 @@ final class RouteCompiler
                     requestBinder: RequestBinder::compile($method, $path->template),
                     responseHandler: ResponseHandler::compile($method),
                     middlewares: $middlewares,
+                    csrfProtected: $csrf && !$route->getMethod()->isSafe(),
                 );
             }
         }
@@ -77,6 +87,22 @@ final class RouteCompiler
         if ($method->isStatic()) {
             throw new LogicException("{$location} cannot be static");
         }
+    }
+
+    /**
+     * @param array<ReflectionAttribute<Csrf>> $attributes
+     */
+    private static function csrf(array $attributes, string $location): bool
+    {
+        if (count($attributes) > 1) {
+            throw new LogicException("{$location} cannot repeat the #[Csrf] attribute");
+        }
+        if ($attributes === []) {
+            return false;
+        }
+        $attributes[0]->newInstance();
+
+        return true;
     }
 
     /**

--- a/src/Router/RouteDefinition.php
+++ b/src/Router/RouteDefinition.php
@@ -22,6 +22,7 @@ final readonly class RouteDefinition
         public RequestBinder $requestBinder,
         public ResponseHandler $responseHandler,
         public array $middlewares,
+        public bool $csrfProtected,
     ) {
     }
 

--- a/src/Security/CsrfMiddleware.php
+++ b/src/Security/CsrfMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace GustavPHP\Gustav\Security;
+
+use GustavPHP\Gustav\Http\Binding\RequestBodyParser;
+use GustavPHP\Gustav\Http\Exception\CsrfException;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Http\Server\{MiddlewareInterface, RequestHandlerInterface};
+
+final readonly class CsrfMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private CsrfTokenManager $tokens,
+        private RequestBodyParser $bodyParser,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $header = $request->getHeader(CsrfTokenManager::HEADER);
+        if ($header !== [] && (count($header) !== 1 || trim($header[0]) === '')) {
+            throw new CsrfException();
+        }
+        $submitted = $header === [] ? null : trim($header[0]);
+
+        $parsed = $request->getParsedBody();
+        if ($submitted === null) {
+            $body = $this->bodyParser->parse($request);
+            $submitted = $body[CsrfTokenManager::FIELD] ?? null;
+            unset($body[CsrfTokenManager::FIELD]);
+            $request = $request->withParsedBody($body);
+        } elseif (is_array($parsed) || is_object($parsed)) {
+            $body = is_array($parsed) ? $parsed : get_object_vars($parsed);
+            unset($body[CsrfTokenManager::FIELD]);
+            $request = $request->withParsedBody($body);
+        }
+
+        if (!$this->tokens->isValid($submitted)) {
+            throw new CsrfException();
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Security/CsrfTokenManager.php
+++ b/src/Security/CsrfTokenManager.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace GustavPHP\Gustav\Security;
+
+use GustavPHP\Gustav\Session;
+
+final readonly class CsrfTokenManager
+{
+    public const FIELD = '_token';
+
+    public const HEADER = 'X-CSRF-Token';
+
+    private const SESSION_KEY = '_csrf_token';
+
+    public function __construct(private Session $session)
+    {
+    }
+
+    public function isValid(mixed $submitted): bool
+    {
+        if (!is_string($submitted) || preg_match('/^[A-Za-z0-9_-]{43}$/D', $submitted) !== 1) {
+            return false;
+        }
+        $stored = $this->session->get(self::SESSION_KEY);
+
+        return is_string($stored) && hash_equals($stored, $submitted);
+    }
+
+    public function rotate(): string
+    {
+        $token = $this->newToken();
+        $this->session->put(self::SESSION_KEY, $token);
+
+        return $token;
+    }
+
+    public function token(): string
+    {
+        $token = $this->session->get(self::SESSION_KEY);
+        if (is_string($token) && preg_match('/^[A-Za-z0-9_-]{43}$/D', $token) === 1) {
+            return $token;
+        }
+
+        return $this->rotate();
+    }
+
+    private function newToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+}

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,0 +1,467 @@
+<?php
+
+namespace GustavPHP\Gustav;
+
+use GustavPHP\Gustav\Session\Exception\SessionStorageException;
+use GustavPHP\Gustav\Session\{SessionLeaseInterface, SessionOptions, SessionRecord, SessionStoreInterface};
+use InvalidArgumentException;
+use LogicException;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Throwable;
+
+final class Session
+{
+    private bool $clearCookie = false;
+
+    private bool $closed = false;
+
+    /** @var array<string,mixed> */
+    private array $data = [];
+
+    private ?string $id = null;
+
+    private ?SessionLeaseInterface $lease = null;
+
+    private bool $loaded = false;
+
+    /** @var array<string,mixed> */
+    private array $newFlash = [];
+
+    /** @var array<string,mixed> */
+    private array $oldFlash = [];
+
+    public function __construct(
+        private readonly SessionStoreInterface $store,
+        private readonly SessionOptions $options,
+        private readonly ServerRequestInterface $request,
+    ) {
+        $cookie = $request->getCookieParams()[$options->cookieName] ?? null;
+        if ($cookie === null) {
+            return;
+        }
+        if (!is_string($cookie) || !$this->validId($cookie)) {
+            $this->clearCookie = true;
+
+            return;
+        }
+
+        $this->id = $cookie;
+    }
+
+    public function __destruct()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        try {
+            $this->releaseLease();
+        } catch (Throwable) {
+        }
+    }
+
+    /** @internal */
+    public function abort(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+        $this->closed = true;
+        $this->releaseLease();
+    }
+
+    /** @return array<string,mixed> */
+    public function all(): array
+    {
+        $this->load();
+
+        return $this->data;
+    }
+
+    /** @return array<string,mixed> */
+    public function allFlash(): array
+    {
+        $this->load();
+
+        return array_merge($this->oldFlash, $this->newFlash);
+    }
+
+    public function clear(): void
+    {
+        $this->load();
+        if ($this->data === []) {
+            return;
+        }
+        $this->ensureSession();
+        $this->data = [];
+    }
+
+    /** @internal */
+    public function complete(ResponseInterface $response): ResponseInterface
+    {
+        $this->assertOpen();
+        $this->closed = true;
+
+        try {
+            if ($response->getStatusCode() >= 500) {
+                return $response;
+            }
+            if ($this->id !== null && $this->lease !== null) {
+                $this->lease->write(new SessionRecord(
+                    data: $this->data,
+                    flash: $this->newFlash,
+                    expiresAt: time() + $this->options->lifetime,
+                ));
+
+                return $response->withAddedHeader('Set-Cookie', $this->sessionCookie());
+            }
+            if ($this->clearCookie) {
+                return $response->withAddedHeader('Set-Cookie', $this->expiredCookie());
+            }
+
+            return $response;
+        } finally {
+            $this->releaseLease();
+        }
+    }
+
+    public function flash(string $key, mixed $value): void
+    {
+        $this->assertKey($key);
+        $this->assertValue($value);
+        $this->load();
+        $this->ensureSession();
+        $this->newFlash[$key] = $value;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->assertKey($key);
+        $this->load();
+
+        return array_key_exists($key, $this->data)
+            ? $this->data[$key]
+            : $default;
+    }
+
+    public function getFlash(string $key, mixed $default = null): mixed
+    {
+        $this->assertKey($key);
+        $this->load();
+        if (array_key_exists($key, $this->newFlash)) {
+            return $this->newFlash[$key];
+        }
+
+        return array_key_exists($key, $this->oldFlash)
+            ? $this->oldFlash[$key]
+            : $default;
+    }
+
+    public function has(string $key): bool
+    {
+        $this->assertKey($key);
+        $this->load();
+
+        return array_key_exists($key, $this->data);
+    }
+
+    public function hasFlash(string $key): bool
+    {
+        $this->assertKey($key);
+        $this->load();
+
+        return array_key_exists($key, $this->newFlash)
+            || array_key_exists($key, $this->oldFlash);
+    }
+
+    public function id(): string
+    {
+        $this->load();
+        $this->ensureSession();
+
+        return $this->id ?? throw new LogicException('Session id was not created');
+    }
+
+    public function invalidate(): void
+    {
+        $this->load();
+        if ($this->lease !== null) {
+            $this->lease->destroy();
+        }
+        $this->releaseLease();
+        $this->id = null;
+        $this->data = [];
+        $this->oldFlash = [];
+        $this->newFlash = [];
+        $this->clearCookie = true;
+    }
+
+    public function keepFlash(string ...$keys): void
+    {
+        $this->load();
+        if ($keys === []) {
+            $keys = array_keys($this->oldFlash);
+        }
+        foreach ($keys as $key) {
+            $this->assertKey($key);
+            if (array_key_exists($key, $this->oldFlash)) {
+                $this->newFlash[$key] = $this->oldFlash[$key];
+            }
+        }
+    }
+
+    public function pull(string $key, mixed $default = null): mixed
+    {
+        $value = $this->get($key, $default);
+        $this->remove($key);
+
+        return $value;
+    }
+
+    public function pullFlash(string $key, mixed $default = null): mixed
+    {
+        $value = $this->getFlash($key, $default);
+        unset($this->oldFlash[$key], $this->newFlash[$key]);
+
+        return $value;
+    }
+
+    public function put(string $key, mixed $value): void
+    {
+        $this->assertKey($key);
+        $this->assertValue($value);
+        $this->load();
+        $this->ensureSession();
+        $this->data[$key] = $value;
+    }
+
+    public function regenerate(): void
+    {
+        $this->load();
+        if ($this->lease !== null) {
+            $this->lease->destroy();
+        }
+        $this->releaseLease();
+        $this->id = null;
+        $this->clearCookie = true;
+        $this->ensureSession();
+    }
+
+    public function remove(string $key): mixed
+    {
+        $this->assertKey($key);
+        $this->load();
+        if (!array_key_exists($key, $this->data)) {
+            return null;
+        }
+        $value = $this->data[$key];
+        unset($this->data[$key]);
+
+        return $value;
+    }
+
+    private function assertKey(string $key): void
+    {
+        $this->assertOpen();
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_.-]*$/D', $key) !== 1) {
+            throw new InvalidArgumentException('Session keys must be valid names');
+        }
+    }
+
+    private function assertOpen(): void
+    {
+        if ($this->closed) {
+            throw new LogicException('Session is no longer active');
+        }
+    }
+
+    private function assertRecord(SessionRecord $record): void
+    {
+        foreach ($record->data as $key => $value) {
+            if (!is_string($key)) {
+                throw new SessionStorageException('Stored session is invalid');
+            }
+            $this->assertStoredKeyAndValue($key, $value);
+        }
+        foreach ($record->flash as $key => $value) {
+            if (!is_string($key)) {
+                throw new SessionStorageException('Stored session is invalid');
+            }
+            $this->assertStoredKeyAndValue($key, $value);
+        }
+    }
+
+    private function assertStoredKeyAndValue(string $key, mixed $value): void
+    {
+        try {
+            $this->assertKey($key);
+            $this->assertValue($value);
+        } catch (InvalidArgumentException $exception) {
+            throw new SessionStorageException('Stored session is invalid', previous: $exception);
+        }
+    }
+
+    private function assertValue(mixed $value, int $depth = 0): void
+    {
+        if ($depth > 64) {
+            throw new InvalidArgumentException('Session values cannot exceed 64 levels');
+        }
+        if ($value === null || is_bool($value) || is_int($value)) {
+            return;
+        }
+        if (is_float($value)) {
+            if (!is_finite($value)) {
+                throw new InvalidArgumentException('Session floats must be finite');
+            }
+
+            return;
+        }
+        if (is_string($value)) {
+            if (preg_match('//u', $value) !== 1) {
+                throw new InvalidArgumentException('Session strings must contain valid UTF-8');
+            }
+
+            return;
+        }
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                if (is_string($key) && preg_match('//u', $key) !== 1) {
+                    throw new InvalidArgumentException('Session array keys must contain valid UTF-8');
+                }
+                $this->assertValue($item, $depth + 1);
+            }
+
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            'Session values must contain only JSON-compatible scalars and arrays',
+        );
+    }
+
+    /** @return list<string> */
+    private function cookieAttributes(int $expiresAt, int $maxAge): array
+    {
+        $attributes = [
+            'Expires=' . gmdate('D, d M Y H:i:s \G\M\T', $expiresAt),
+            "Max-Age={$maxAge}",
+            "Path={$this->options->cookiePath}",
+        ];
+        if ($this->options->cookieDomain !== null) {
+            $attributes[] = "Domain={$this->options->cookieDomain}";
+        }
+        if ($this->secureCookie()) {
+            $attributes[] = 'Secure';
+        }
+        $attributes[] = 'HttpOnly';
+        $attributes[] = 'SameSite=' . $this->options->sameSite->value;
+
+        return $attributes;
+    }
+
+    private function ensureSession(): void
+    {
+        if ($this->id !== null && $this->lease !== null) {
+            return;
+        }
+
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $id = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+            $lease = $this->store->acquire($id, true);
+            if ($lease === null) {
+                continue;
+            }
+            try {
+                if ($lease->read() !== null) {
+                    $lease->release();
+                    continue;
+                }
+            } catch (Throwable $exception) {
+                $lease->release();
+                throw $exception;
+            }
+
+            $this->id = $id;
+            $this->lease = $lease;
+            $this->clearCookie = false;
+
+            return;
+        }
+
+        throw new SessionStorageException('Unable to allocate a unique session id');
+    }
+
+    private function expiredCookie(): string
+    {
+        return implode('; ', [
+            $this->options->cookieName . '=',
+            ...$this->cookieAttributes(0, 0),
+        ]);
+    }
+
+    private function load(): void
+    {
+        $this->assertOpen();
+        if ($this->loaded) {
+            return;
+        }
+        $this->loaded = true;
+        if ($this->id === null) {
+            return;
+        }
+
+        $lease = $this->store->acquire($this->id);
+        if ($lease === null) {
+            $this->id = null;
+            $this->clearCookie = true;
+
+            return;
+        }
+        $this->lease = $lease;
+        try {
+            $record = $lease->read();
+            if ($record === null || $record->expiresAt <= time()) {
+                $lease->destroy();
+                $this->releaseLease();
+                $this->id = null;
+                $this->clearCookie = true;
+
+                return;
+            }
+            $this->assertRecord($record);
+            $this->data = $record->data;
+            $this->oldFlash = $record->flash;
+        } catch (Throwable $exception) {
+            $this->releaseLease();
+            throw $exception;
+        }
+    }
+
+    private function releaseLease(): void
+    {
+        $lease = $this->lease;
+        $this->lease = null;
+        $lease?->release();
+    }
+
+    private function secureCookie(): bool
+    {
+        return $this->options->secure
+            ?? strtolower($this->request->getUri()->getScheme()) === 'https';
+    }
+
+    private function sessionCookie(): string
+    {
+        $id = $this->id ?? throw new LogicException('Session id is missing');
+
+        return implode('; ', [
+            $this->options->cookieName . '=' . $id,
+            ...$this->cookieAttributes(time() + $this->options->lifetime, $this->options->lifetime),
+        ]);
+    }
+
+    private function validId(string $id): bool
+    {
+        return preg_match('/^[A-Za-z0-9_-]{43}$/D', $id) === 1;
+    }
+}

--- a/src/Session/Exception/SessionException.php
+++ b/src/Session/Exception/SessionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GustavPHP\Gustav\Session\Exception;
+
+use RuntimeException;
+
+class SessionException extends RuntimeException
+{
+}

--- a/src/Session/Exception/SessionStorageException.php
+++ b/src/Session/Exception/SessionStorageException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GustavPHP\Gustav\Session\Exception;
+
+final class SessionStorageException extends SessionException
+{
+}

--- a/src/Session/FileSessionLease.php
+++ b/src/Session/FileSessionLease.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+use GustavPHP\Gustav\Session\Exception\SessionStorageException;
+use JsonException;
+
+/** @internal */
+final class FileSessionLease implements SessionLeaseInterface
+{
+    private bool $released = false;
+
+    /** @param resource $handle */
+    public function __construct(private $handle)
+    {
+    }
+
+    public function __destruct()
+    {
+        $this->release();
+    }
+
+    public function destroy(): void
+    {
+        $this->writeBytes('');
+    }
+
+    public function read(): ?SessionRecord
+    {
+        $this->assertActive();
+        if (rewind($this->handle) === false) {
+            throw new SessionStorageException('Unable to read stored session');
+        }
+        $contents = stream_get_contents($this->handle);
+        if ($contents === false) {
+            throw new SessionStorageException('Unable to read stored session');
+        }
+        if ($contents === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new SessionStorageException('Stored session is invalid', previous: $exception);
+        }
+        if (
+            !is_array($decoded)
+            || !is_int($decoded['expires_at'] ?? null)
+            || !is_array($decoded['data'] ?? null)
+            || !is_array($decoded['flash'] ?? null)
+        ) {
+            throw new SessionStorageException('Stored session is invalid');
+        }
+
+        /** @var array<string,mixed> $data */
+        $data = $decoded['data'];
+        /** @var array<string,mixed> $flash */
+        $flash = $decoded['flash'];
+
+        return new SessionRecord($data, $flash, $decoded['expires_at']);
+    }
+
+    public function release(): void
+    {
+        if ($this->released) {
+            return;
+        }
+        $this->released = true;
+        @flock($this->handle, LOCK_UN);
+        @fclose($this->handle);
+    }
+
+    public function write(SessionRecord $record): void
+    {
+        try {
+            $contents = json_encode(
+                [
+                    'expires_at' => $record->expiresAt,
+                    'data' => $record->data,
+                    'flash' => $record->flash,
+                ],
+                JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES,
+            );
+        } catch (JsonException $exception) {
+            throw new SessionStorageException('Session data could not be encoded', previous: $exception);
+        }
+
+        $this->writeBytes($contents);
+    }
+
+    private function assertActive(): void
+    {
+        if ($this->released) {
+            throw new SessionStorageException('Session storage lease has already been released');
+        }
+    }
+
+    private function writeBytes(string $contents): void
+    {
+        $this->assertActive();
+        if (rewind($this->handle) === false || !ftruncate($this->handle, 0)) {
+            throw new SessionStorageException('Unable to write stored session');
+        }
+
+        $length = strlen($contents);
+        $written = 0;
+        while ($written < $length) {
+            $chunk = fwrite($this->handle, substr($contents, $written));
+            if ($chunk === false || $chunk === 0) {
+                throw new SessionStorageException('Unable to write stored session');
+            }
+            $written += $chunk;
+        }
+        if (!fflush($this->handle)) {
+            throw new SessionStorageException('Unable to flush stored session');
+        }
+        if (function_exists('fsync') && !@fsync($this->handle)) {
+            throw new SessionStorageException('Unable to synchronize stored session');
+        }
+    }
+}

--- a/src/Session/FileSessionStore.php
+++ b/src/Session/FileSessionStore.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+use DirectoryIterator;
+use GustavPHP\Gustav\Session\Exception\SessionStorageException;
+use InvalidArgumentException;
+
+final class FileSessionStore implements SessionStoreInterface
+{
+    private ?string $resolvedDirectory = null;
+
+    public function __construct(private readonly SessionOptions $options)
+    {
+    }
+
+    public function acquire(string $id, bool $create = false): ?SessionLeaseInterface
+    {
+        $this->assertId($id);
+        $directory = $this->directory();
+        $this->maybeCollectGarbage();
+        $filename = $directory . DIRECTORY_SEPARATOR . hash('sha256', $id) . '.session';
+        if (!$create && !is_file($filename)) {
+            return null;
+        }
+
+        $handle = @fopen($filename, $create ? 'c+b' : 'r+b');
+        if ($handle === false) {
+            if (!$create && !is_file($filename)) {
+                return null;
+            }
+
+            throw new SessionStorageException('Unable to open session storage');
+        }
+        @chmod($filename, 0600);
+        if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
+            throw new SessionStorageException('Unable to lock session storage');
+        }
+
+        return new FileSessionLease($handle);
+    }
+
+    public function collectGarbage(?int $now = null): void
+    {
+        $now ??= time();
+        foreach (new DirectoryIterator($this->directory()) as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'session') {
+                continue;
+            }
+            $handle = @fopen($file->getPathname(), 'r+b');
+            if ($handle === false || !flock($handle, LOCK_EX | LOCK_NB)) {
+                if (is_resource($handle)) {
+                    fclose($handle);
+                }
+                continue;
+            }
+
+            $remove = false;
+            $lease = new FileSessionLease($handle);
+            try {
+                $record = $lease->read();
+                $remove = $record === null || $record->expiresAt <= $now;
+            } catch (SessionStorageException) {
+                $remove = true;
+            }
+            if ($remove) {
+                $lease->destroy();
+            }
+            $pathname = $file->getPathname();
+            $lease->release();
+            if ($remove) {
+                @unlink($pathname);
+            }
+        }
+    }
+
+    private function assertId(string $id): void
+    {
+        if (preg_match('/^[A-Za-z0-9_-]{43}$/D', $id) !== 1) {
+            throw new InvalidArgumentException('Session id is invalid');
+        }
+    }
+
+    private function directory(): string
+    {
+        if ($this->resolvedDirectory !== null) {
+            return $this->resolvedDirectory;
+        }
+        $directory = $this->options->directory;
+        if ($directory === null) {
+            throw new SessionStorageException(
+                'The default session store requires a configured directory',
+            );
+        }
+        if (!is_dir($directory) && !@mkdir($directory, 0700, true) && !is_dir($directory)) {
+            throw new SessionStorageException("Session directory '{$directory}' could not be created");
+        }
+        $resolved = realpath($directory);
+        if ($resolved === false || !is_dir($resolved) || !is_readable($resolved) || !is_writable($resolved)) {
+            throw new SessionStorageException("Session directory '{$directory}' is not readable and writable");
+        }
+
+        return $this->resolvedDirectory = $resolved;
+    }
+
+    private function maybeCollectGarbage(): void
+    {
+        $probability = $this->options->garbageCollectionProbability;
+        if ($probability > 0 && random_int(1, 100) <= $probability) {
+            $this->collectGarbage();
+        }
+    }
+}

--- a/src/Session/SameSite.php
+++ b/src/Session/SameSite.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+enum SameSite: string
+{
+    case Lax = 'Lax';
+    case None = 'None';
+    case Strict = 'Strict';
+}

--- a/src/Session/SessionLeaseInterface.php
+++ b/src/Session/SessionLeaseInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+interface SessionLeaseInterface
+{
+    /** Delete the current record while retaining the lease until release. */
+    public function destroy(): void;
+
+    /** Read the current record, or null when this is a newly created lease. */
+    public function read(): ?SessionRecord;
+
+    /** Release exclusive access. Implementations must make this idempotent. */
+    public function release(): void;
+
+    /** Replace the complete record atomically before the lease is released. */
+    public function write(SessionRecord $record): void;
+}

--- a/src/Session/SessionMiddleware.php
+++ b/src/Session/SessionMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+use GustavPHP\Gustav\Session;
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Http\Server\{MiddlewareInterface, RequestHandlerInterface};
+use Throwable;
+
+final readonly class SessionMiddleware implements MiddlewareInterface
+{
+    public function __construct(private Session $session)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        try {
+            $response = $handler->handle($request);
+        } catch (Throwable $exception) {
+            $this->session->abort();
+            throw $exception;
+        }
+
+        return $this->session->complete($response);
+    }
+}

--- a/src/Session/SessionOptions.php
+++ b/src/Session/SessionOptions.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+use InvalidArgumentException;
+
+final readonly class SessionOptions
+{
+    public function __construct(
+        public ?string $directory = null,
+        public string $cookieName = 'gustav_session',
+        public int $lifetime = 7200,
+        public string $cookiePath = '/',
+        public ?string $cookieDomain = null,
+        public ?bool $secure = null,
+        public SameSite $sameSite = SameSite::Lax,
+        public int $garbageCollectionProbability = 1,
+    ) {
+        if ($directory !== null && (trim($directory) === '' || str_contains($directory, "\0"))) {
+            throw new InvalidArgumentException('Session directory must be a non-empty path');
+        }
+        if (preg_match('/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/D', $cookieName) !== 1) {
+            throw new InvalidArgumentException('Session cookie name is invalid');
+        }
+        if ($lifetime < 1) {
+            throw new InvalidArgumentException('Session lifetime must be greater than zero');
+        }
+        if (
+            !str_starts_with($cookiePath, '/')
+            || preg_match('/[;,\x00-\x1F\x7F]/', $cookiePath) === 1
+        ) {
+            throw new InvalidArgumentException('Session cookie path is invalid');
+        }
+        if (
+            $cookieDomain !== null
+            && (
+                trim($cookieDomain) === ''
+                || preg_match('/[;,\s\x00-\x1F\x7F]/', $cookieDomain) === 1
+            )
+        ) {
+            throw new InvalidArgumentException('Session cookie domain is invalid');
+        }
+        if ($sameSite === SameSite::None && $secure !== true) {
+            throw new InvalidArgumentException('SameSite=None session cookies must explicitly enable Secure');
+        }
+        if (str_starts_with($cookieName, '__Secure-') && $secure !== true) {
+            throw new InvalidArgumentException('__Secure- session cookies must explicitly enable Secure');
+        }
+        if (
+            str_starts_with($cookieName, '__Host-')
+            && ($secure !== true || $cookieDomain !== null || $cookiePath !== '/')
+        ) {
+            throw new InvalidArgumentException(
+                '__Host- session cookies require Secure, Path=/, and no Domain',
+            );
+        }
+        if ($garbageCollectionProbability < 0 || $garbageCollectionProbability > 100) {
+            throw new InvalidArgumentException(
+                'Session garbage collection probability must be between 0 and 100',
+            );
+        }
+    }
+}

--- a/src/Session/SessionRecord.php
+++ b/src/Session/SessionRecord.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+final readonly class SessionRecord
+{
+    /**
+     * @param array<string,mixed> $data
+     * @param array<string,mixed> $flash
+     */
+    public function __construct(
+        public array $data,
+        public array $flash,
+        public int $expiresAt,
+    ) {
+    }
+}

--- a/src/Session/SessionStoreInterface.php
+++ b/src/Session/SessionStoreInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GustavPHP\Gustav\Session;
+
+interface SessionStoreInterface
+{
+    /**
+     * Acquire exclusive access to one session for the current request.
+     *
+     * A missing session returns null unless $create is true. Every returned
+     * lease must be released by the caller.
+     */
+    public function acquire(string $id, bool $create = false): ?SessionLeaseInterface;
+}

--- a/tests/Integration/Routes/Sessions.php
+++ b/tests/Integration/Routes/Sessions.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace GustavPHP\Tests\Integration\Routes;
+
+use GustavPHP\Gustav\Attribute\{Body, Controller, Csrf, Get, Post};
+use GustavPHP\Gustav\Security\CsrfTokenManager;
+use GustavPHP\Gustav\Session;
+use RuntimeException;
+
+#[Controller('/sessions')]
+#[Csrf]
+final class Sessions
+{
+    public function __construct(
+        private readonly Session $session,
+        private readonly CsrfTokenManager $csrf,
+    ) {
+    }
+
+    /** @return array{notice:mixed} */
+    #[Get('/flash')]
+    public function flash(): array
+    {
+        return ['notice' => $this->session->getFlash('notice')];
+    }
+
+    /** @return array{value:mixed} */
+    #[Get('/value')]
+    public function getValue(): array
+    {
+        return ['value' => $this->session->get('value')];
+    }
+
+    /** @return array{ok:true} */
+    #[Post('/invalidate')]
+    public function invalidate(): array
+    {
+        $this->session->invalidate();
+
+        return ['ok' => true];
+    }
+
+    /** @return array{old:string,new:string,value:mixed} */
+    #[Post('/regenerate')]
+    public function regenerate(): array
+    {
+        $old = $this->session->id();
+        $this->session->regenerate();
+
+        return [
+            'old' => $old,
+            'new' => $this->session->id(),
+            'value' => $this->session->get('value'),
+        ];
+    }
+
+    /** @return array{stored:string} */
+    #[Post('/flash')]
+    public function setFlash(#[Body('message')] string $message): array
+    {
+        $this->session->flash('notice', $message);
+
+        return ['stored' => $message];
+    }
+
+    /** @return array{value:string,token_present:bool} */
+    #[Post('/value')]
+    public function setValue(
+        #[Body] array $body,
+        #[Body('value')] string $value,
+    ): array {
+        $this->session->put('value', $value);
+
+        return [
+            'value' => $value,
+            'token_present' => array_key_exists(CsrfTokenManager::FIELD, $body),
+        ];
+    }
+
+    /** @return array{ok:true} */
+    #[Post('/fail')]
+    public function storeThenFail(): array
+    {
+        $this->session->put('value', 'should-not-commit');
+
+        throw new RuntimeException('private session failure');
+    }
+
+    /** @return array{token:string,session_id:string} */
+    #[Get('/token')]
+    public function token(): array
+    {
+        return [
+            'token' => $this->csrf->token(),
+            'session_id' => $this->session->id(),
+        ];
+    }
+}

--- a/tests/Integration/Tests/ObservabilityTest.php
+++ b/tests/Integration/Tests/ObservabilityTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Session\SessionOptions;
 use GustavPHP\Tests\Fixtures\Observability\Services\RecordingLogger;
+
+use function GustavPHP\Tests\Integration\integrationSessionDirectory;
+
 use Nyholm\Psr7\ServerRequest;
 use Psr\Log\LogLevel;
 
@@ -13,6 +17,7 @@ function observabilityApplication(
         mode: $mode,
         namespace: $namespace,
         routeNamespaces: ['GustavPHP\\Tests\\Integration\\Routes'],
+        session: new SessionOptions(directory: integrationSessionDirectory()),
     ));
 }
 

--- a/tests/Integration/Tests/SessionTest.php
+++ b/tests/Integration/Tests/SessionTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use GustavPHP\Gustav\Security\CsrfTokenManager;
+use GustavPHP\Tests\Integration\Client;
+
+use function GustavPHP\Tests\Integration\createClient;
+
+use Psr\Http\Message\ResponseInterface;
+
+/** @return array{token:string,id:string,cookies:array{gustav_session:string}} */
+function integrationSessionCredentials(Client $client): array
+{
+    $response = $client->request('GET', '/sessions/token');
+    $body = json_decode((string) $response->getBody(), true);
+    $id = integrationSessionCookieId($response);
+
+    return [
+        'token' => $body['token'],
+        'id' => $id,
+        'cookies' => ['gustav_session' => $id],
+    ];
+}
+
+function integrationSessionCookieId(ResponseInterface $response): string
+{
+    $cookie = $response->getHeader('Set-Cookie')[0] ?? '';
+    preg_match('/^gustav_session=([^;]*)/', $cookie, $matches);
+
+    return $matches[1] ?? '';
+}
+
+function integrationJson(ResponseInterface $response): array
+{
+    $body = json_decode((string) $response->getBody(), true);
+    expect($body)->toBeArray();
+
+    return $body;
+}
+
+it('keeps sessions lazy on safe requests that only read missing state', function () {
+    $response = createClient()->request('GET', '/sessions/value');
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and(integrationJson($response))->toBe(['value' => null])
+        ->and($response->hasHeader('Set-Cookie'))->toBeFalse();
+});
+
+it('returns a structured 403 before a protected controller runs', function (array $options) {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $options['cookies'] = $credentials['cookies'];
+    $response = $client->request('POST', '/sessions/value', $options);
+
+    expect($response->getStatusCode())->toBe(403)
+        ->and($response->getHeaderLine('Content-Type'))->toBe('application/json')
+        ->and(integrationJson($response))->toBe([
+            'error' => [
+                'status' => 403,
+                'message' => 'CSRF token is invalid',
+            ],
+        ]);
+})->with([
+    'missing token' => [['form_params' => ['value' => 'blocked']]],
+    'invalid token' => [[
+        'headers' => [CsrfTokenManager::HEADER => str_repeat('a', 43)],
+        'json' => ['value' => 'blocked'],
+    ]],
+]);
+
+it('preserves body syntax errors while looking for a form token', function (string $contentType, string $body, int $status) {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $response = $client->request('POST', '/sessions/value', [
+        'cookies' => $credentials['cookies'],
+        'headers' => ['Content-Type' => $contentType],
+        'body' => $body,
+    ]);
+
+    expect($response->getStatusCode())->toBe($status);
+})->with([
+    'malformed JSON' => ['application/json', '{"_token":', 400],
+    'unsupported body media type' => ['text/plain', 'not-form-data', 415],
+]);
+
+it('accepts a form token and strips it before request binding', function () {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $response = $client->request('POST', '/sessions/value', [
+        'cookies' => $credentials['cookies'],
+        'form_params' => [
+            CsrfTokenManager::FIELD => $credentials['token'],
+            'value' => 'form',
+        ],
+    ]);
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and(integrationJson($response))->toBe([
+            'value' => 'form',
+            'token_present' => false,
+        ]);
+});
+
+it('accepts a CSRF header for JSON requests and persists between application instances', function () {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $stored = $client->request('POST', '/sessions/value', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+        'json' => ['value' => 'json'],
+    ]);
+    $restored = $client->request('GET', '/sessions/value', [
+        'cookies' => $credentials['cookies'],
+    ]);
+
+    expect($stored->getStatusCode())->toBe(200)
+        ->and(integrationJson($stored))->toBe(['value' => 'json', 'token_present' => false])
+        ->and(integrationJson($restored))->toBe(['value' => 'json']);
+});
+
+it('exposes flash data for exactly the next request', function () {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $stored = $client->request('POST', '/sessions/flash', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+        'json' => ['message' => 'Saved'],
+    ]);
+    $first = $client->request('GET', '/sessions/flash', ['cookies' => $credentials['cookies']]);
+    $second = $client->request('GET', '/sessions/flash', ['cookies' => $credentials['cookies']]);
+
+    expect($stored->getStatusCode())->toBe(200)
+        ->and(integrationJson($first))->toBe(['notice' => 'Saved'])
+        ->and(integrationJson($second))->toBe(['notice' => null]);
+});
+
+it('regenerates the identifier while preserving state and invalidating the old id', function () {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $client->request('POST', '/sessions/value', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+        'json' => ['value' => 'preserved'],
+    ]);
+    $regenerated = $client->request('POST', '/sessions/regenerate', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+    ]);
+    $body = integrationJson($regenerated);
+    $newId = integrationSessionCookieId($regenerated);
+    $old = $client->request('GET', '/sessions/value', ['cookies' => $credentials['cookies']]);
+    $current = $client->request('GET', '/sessions/value', [
+        'cookies' => ['gustav_session' => $newId],
+    ]);
+
+    expect($body)->toBe([
+        'old' => $credentials['id'],
+        'new' => $newId,
+        'value' => 'preserved',
+    ])->and($newId)->not->toBe($credentials['id'])
+        ->and(integrationJson($old))->toBe(['value' => null])
+        ->and(integrationJson($current))->toBe(['value' => 'preserved']);
+});
+
+it('invalidates session state and expires the cookie', function () {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $response = $client->request('POST', '/sessions/invalidate', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+    ]);
+    $after = $client->request('GET', '/sessions/value', ['cookies' => $credentials['cookies']]);
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getHeaderLine('Set-Cookie'))->toContain('Max-Age=0')
+        ->and(integrationJson($after))->toBe(['value' => null]);
+});
+
+it('does not commit session mutations from a failed request and keeps serving', function () {
+    $client = createClient();
+    $credentials = integrationSessionCredentials($client);
+    $client->request('POST', '/sessions/value', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+        'json' => ['value' => 'before'],
+    ]);
+    $failed = $client->request('POST', '/sessions/fail', [
+        'cookies' => $credentials['cookies'],
+        'headers' => [CsrfTokenManager::HEADER => $credentials['token']],
+    ]);
+    $after = $client->request('GET', '/sessions/value', ['cookies' => $credentials['cookies']]);
+
+    expect($failed->getStatusCode())->toBe(500)
+        ->and(integrationJson($failed))->toBe([
+            'error' => [
+                'status' => 500,
+                'message' => 'Server Error',
+            ],
+        ])->and((string) $failed->getBody())->not->toContain('private session failure')
+        ->and(integrationJson($after))->toBe(['value' => 'before']);
+});

--- a/tests/Integration/app.php
+++ b/tests/Integration/app.php
@@ -5,10 +5,12 @@ namespace GustavPHP\Tests\Integration;
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Session\SessionOptions;
 
 Application::run(new Configuration(
     mode: Mode::Production,
     namespace: __NAMESPACE__,
     files: __DIR__ . '/public/',
     views: __DIR__ . '/views/',
+    session: new SessionOptions(directory: integrationSessionDirectory()),
 ));

--- a/tests/Integration/helpers.php
+++ b/tests/Integration/helpers.php
@@ -3,6 +3,34 @@
 namespace GustavPHP\Tests\Integration;
 
 use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Session\SessionOptions;
+
+function integrationSessionDirectory(): string
+{
+    static $directory;
+    if (is_string($directory)) {
+        return $directory;
+    }
+    $directory = sys_get_temp_dir()
+        . DIRECTORY_SEPARATOR
+        . 'gustav-integration-sessions-'
+        . getmypid()
+        . '-'
+        . bin2hex(random_bytes(4));
+    register_shutdown_function(function () use ($directory): void {
+        if (!is_dir($directory)) {
+            return;
+        }
+        foreach (new \DirectoryIterator($directory) as $file) {
+            if ($file->isFile()) {
+                @unlink($file->getPathname());
+            }
+        }
+        @rmdir($directory);
+    });
+
+    return $directory;
+}
 
 function createApplication(Mode $mode = Mode::Production): Application
 {
@@ -11,6 +39,7 @@ function createApplication(Mode $mode = Mode::Production): Application
         namespace: __NAMESPACE__,
         views: __DIR__ . '/views/',
         serviceNamespaces: ['GustavPHP\\Tests\\Fixtures\\QuietLogging\\Services'],
+        session: new SessionOptions(directory: integrationSessionDirectory()),
     ));
 }
 

--- a/tests/RouterFixtures/DuplicateCsrfController.php
+++ b/tests/RouterFixtures/DuplicateCsrfController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GustavPHP\Tests\RouterFixtures;
+
+use GustavPHP\Gustav\Attribute\{Controller, Csrf, Post};
+
+#[Controller]
+final class DuplicateCsrfController
+{
+    /** @return array{} */
+    #[Csrf]
+    #[Csrf]
+    #[Post('/duplicate-csrf')]
+    public function store(): array
+    {
+        return [];
+    }
+}

--- a/tests/RouterFixtures/ValidController.php
+++ b/tests/RouterFixtures/ValidController.php
@@ -2,9 +2,10 @@
 
 namespace GustavPHP\Tests\RouterFixtures;
 
-use GustavPHP\Gustav\Attribute\{Controller, Get, Param, Post};
+use GustavPHP\Gustav\Attribute\{Controller, Csrf, Get, Param, Post};
 
 #[Controller('/blog')]
+#[Csrf]
 final class ValidController
 {
     /** @return array{} */

--- a/tests/SessionFixtures/MemorySessionLease.php
+++ b/tests/SessionFixtures/MemorySessionLease.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace GustavPHP\Tests\SessionFixtures;
+
+use GustavPHP\Gustav\Session\{SessionLeaseInterface, SessionRecord};
+use LogicException;
+
+final class MemorySessionLease implements SessionLeaseInterface
+{
+    private bool $released = false;
+
+    public function __construct(
+        private readonly MemorySessionStore $store,
+        private readonly string $id,
+    ) {
+    }
+
+    public function destroy(): void
+    {
+        $this->assertActive();
+        $this->store->delete($this->id);
+    }
+
+    public function read(): ?SessionRecord
+    {
+        $this->assertActive();
+
+        return $this->store->read($this->id);
+    }
+
+    public function release(): void
+    {
+        $this->released = true;
+    }
+
+    public function write(SessionRecord $record): void
+    {
+        $this->assertActive();
+        $this->store->write($this->id, $record);
+    }
+
+    private function assertActive(): void
+    {
+        if ($this->released) {
+            throw new LogicException('Memory session lease has already been released');
+        }
+    }
+}

--- a/tests/SessionFixtures/MemorySessionStore.php
+++ b/tests/SessionFixtures/MemorySessionStore.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace GustavPHP\Tests\SessionFixtures;
+
+use GustavPHP\Gustav\Session\{SessionLeaseInterface, SessionRecord, SessionStoreInterface};
+
+class MemorySessionStore implements SessionStoreInterface
+{
+    public int $acquisitions = 0;
+
+    /** @var array<string,SessionRecord|null> */
+    private array $records = [];
+
+    public function acquire(string $id, bool $create = false): ?SessionLeaseInterface
+    {
+        $this->acquisitions++;
+        if (!array_key_exists($id, $this->records)) {
+            if (!$create) {
+                return null;
+            }
+            $this->records[$id] = null;
+        }
+
+        return new MemorySessionLease($this, $id);
+    }
+
+    public function delete(string $id): void
+    {
+        unset($this->records[$id]);
+    }
+
+    /** @return list<string> */
+    public function ids(): array
+    {
+        return array_keys($this->records);
+    }
+
+    public function read(string $id): ?SessionRecord
+    {
+        return $this->records[$id] ?? null;
+    }
+
+    public function write(string $id, SessionRecord $record): void
+    {
+        $this->records[$id] = $record;
+    }
+}

--- a/tests/SessionStoreFixtures/InvalidApplication/Routes/ProtectedRoute.php
+++ b/tests/SessionStoreFixtures/InvalidApplication/Routes/ProtectedRoute.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GustavPHP\Tests\SessionStoreFixtures\InvalidApplication\Routes;
+
+use GustavPHP\Gustav\Attribute\{Controller, Csrf, Post};
+
+#[Controller]
+final class ProtectedRoute
+{
+    /** @return array{ok:true} */
+    #[Csrf]
+    #[Post('/protected')]
+    public function store(): array
+    {
+        return ['ok' => true];
+    }
+}

--- a/tests/SessionStoreFixtures/ValidApplication/Routes/SessionRoute.php
+++ b/tests/SessionStoreFixtures/ValidApplication/Routes/SessionRoute.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GustavPHP\Tests\SessionStoreFixtures\ValidApplication\Routes;
+
+use GustavPHP\Gustav\Attribute\{Controller, Get};
+use GustavPHP\Gustav\Session;
+
+#[Controller]
+final class SessionRoute
+{
+    public function __construct(private readonly Session $session)
+    {
+    }
+
+    /** @return array{visits:int} */
+    #[Get('/session-store')]
+    public function show(): array
+    {
+        $visits = (int) $this->session->get('visits', 0) + 1;
+        $this->session->put('visits', $visits);
+
+        return ['visits' => $visits];
+    }
+}

--- a/tests/SessionStoreFixtures/ValidApplication/Services/DiscoveredSessionStore.php
+++ b/tests/SessionStoreFixtures/ValidApplication/Services/DiscoveredSessionStore.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GustavPHP\Tests\SessionStoreFixtures\ValidApplication\Services;
+
+use GustavPHP\Gustav\Attribute\Service;
+use GustavPHP\Gustav\Service\Lifetime;
+use GustavPHP\Gustav\Session\{SessionLeaseInterface, SessionStoreInterface};
+use GustavPHP\Tests\SessionFixtures\MemorySessionStore;
+
+#[Service(as: SessionStoreInterface::class, lifetime: Lifetime::Singleton)]
+final class DiscoveredSessionStore extends MemorySessionStore
+{
+    public static int $uses = 0;
+
+    public function acquire(string $id, bool $create = false): ?SessionLeaseInterface
+    {
+        self::$uses++;
+
+        return parent::acquire($id, $create);
+    }
+}

--- a/tests/Transport/run.php
+++ b/tests/Transport/run.php
@@ -158,6 +158,19 @@ function responseHeader(array $response, string $name): string
 }
 
 /**
+ * @param array{status: int, body: string, headers: array<int, string>} $response
+ */
+function responseCookiePair(array $response): string
+{
+    $setCookie = responseHeader($response, 'Set-Cookie');
+    if ($setCookie === '' || !str_contains($setCookie, '=')) {
+        throw new RuntimeException('Response did not contain a session cookie');
+    }
+
+    return explode(';', $setCookie, 2)[0];
+}
+
+/**
  * @return array{request: int, singleton: int}
  */
 function serviceLifecycle(int $port): array
@@ -239,6 +252,50 @@ try {
     );
     assertStatus($malformed, 400, 'Malformed JSON request');
 
+    $csrfSeed = request($httpPort, 'GET', '/sessions/token');
+    assertStatus($csrfSeed, 200, 'CSRF token request');
+    $csrfBody = decodeJson($csrfSeed['body'], 'CSRF token response');
+    $csrfToken = $csrfBody['token'] ?? null;
+    if (!is_string($csrfToken)) {
+        throw new RuntimeException('CSRF token response did not contain a token');
+    }
+    $sessionCookie = responseCookiePair($csrfSeed);
+
+    $csrfRejected = request(
+        $httpPort,
+        'POST',
+        '/sessions/value',
+        '{"value":"blocked"}',
+        [
+            'Content-Type' => 'application/json',
+            'Cookie' => $sessionCookie,
+        ],
+    );
+    assertStatus($csrfRejected, 403, 'Missing CSRF token request');
+
+    $csrfAccepted = request(
+        $httpPort,
+        'POST',
+        '/sessions/value',
+        '{"value":"transport"}',
+        [
+            'Content-Type' => 'application/json',
+            'Cookie' => $sessionCookie,
+            'X-CSRF-Token' => $csrfToken,
+        ],
+    );
+    assertStatus($csrfAccepted, 200, 'Valid CSRF JSON request');
+    $sessionValue = request(
+        $httpPort,
+        'GET',
+        '/sessions/value',
+        headers: ['Cookie' => $sessionCookie],
+    );
+    assertStatus($sessionValue, 200, 'Session request after rejected CSRF request');
+    if ((decodeJson($sessionValue['body'], 'Session value response')['value'] ?? null) !== 'transport') {
+        throw new RuntimeException('Session state did not survive the RoadRunner request sequence');
+    }
+
     $view = request($httpPort, 'GET', '/responses/direct-view');
     assertStatus($view, 202, 'Native view request');
     if (
@@ -303,6 +360,7 @@ try {
     echo "RoadRunner transport contract passed\n";
     echo "  JSON request: 200\n";
     echo "  Malformed JSON: 400\n";
+    echo "  Session/CSRF: 200 -> 403 -> 200 -> 200\n";
     echo "  Native views: 202 -> 500 -> 200\n";
     echo "  Worker sequence: 200 -> 418 -> 200\n";
     echo "  Server failure: 500 -> 200 (transport-request-500 logged)\n";

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -3,6 +3,7 @@
 use GustavPHP\Gustav\Config\Environment;
 use GustavPHP\Gustav\Config\Exception\ConfigurationException;
 use GustavPHP\Gustav\{Configuration, Mode};
+use GustavPHP\Gustav\Session\SessionOptions;
 
 it('builds conventional project paths and mode from a captured environment', function () {
     $configuration = Configuration::forProject(
@@ -17,6 +18,7 @@ it('builds conventional project paths and mode from a captured environment', fun
         ->and($configuration->namespace)->toBe('App')
         ->and($configuration->files)->toBe('/srv/example/public/')
         ->and($configuration->views)->toBe('/srv/example/views/')
+        ->and($configuration->session?->directory)->toBe('/srv/example/storage/sessions/')
         ->and($configuration->configurationNamespaces)->toBe(['Module\\Billing\\Config'])
         ->and($configuration->commandNamespaces)->toBe(['Module\\Billing\\Commands']);
 });
@@ -27,6 +29,17 @@ it('defaults conventional projects to development mode', function () {
         root: '/srv/example/',
         environment: Environment::fromArray([]),
     )->mode)->toBe(Mode::Development);
+});
+
+it('accepts custom conventional session options', function () {
+    $session = new SessionOptions(directory: '/var/run/example-sessions', secure: true);
+
+    expect(Configuration::forProject(
+        namespace: 'App',
+        root: '/srv/example/',
+        environment: Environment::fromArray([]),
+        session: $session,
+    )->session)->toBe($session);
 });
 
 it('rejects invalid modes without exposing the supplied value', function () {

--- a/tests/Unit/Router/RouterTest.php
+++ b/tests/Unit/Router/RouterTest.php
@@ -2,7 +2,7 @@
 
 use GustavPHP\Gustav\Http\Exception\HttpException;
 use GustavPHP\Gustav\Router\{Method, RouteCompiler, Router};
-use GustavPHP\Tests\RouterFixtures\{AmbiguousController, DuplicateNameController, ValidController};
+use GustavPHP\Tests\RouterFixtures\{AmbiguousController, DuplicateCsrfController, DuplicateNameController, ValidController};
 
 function compiledRouter(): Router
 {
@@ -36,6 +36,15 @@ it('matches the declared HTTP method and lets HEAD fall back to GET', function (
             fn (Method $method): string => $method->value,
             $router->allowedMethods('/blog/authors'),
         ))->toBe(['GET', 'HEAD', 'OPTIONS']);
+});
+
+it('compiles CSRF protection only for unsafe controller routes', function () {
+    $router = compiledRouter();
+
+    expect($router->match(Method::POST, '/blog')->route->csrfProtected)->toBeTrue()
+        ->and($router->match(Method::GET, '/blog')->route->csrfProtected)->toBeFalse()
+        ->and(Method::OPTIONS->isSafe())->toBeTrue()
+        ->and(Method::DELETE->isSafe())->toBeFalse();
 });
 
 it('distinguishes missing paths from unsupported methods', function () {
@@ -82,3 +91,7 @@ it('rejects ambiguous route patterns during compilation', function () {
 it('rejects duplicate route names during compilation', function () {
     new Router(RouteCompiler::compile(DuplicateNameController::class));
 })->throws(InvalidArgumentException::class, "Route name 'duplicate' is declared by both");
+
+it('rejects repeated CSRF metadata during compilation', function () {
+    RouteCompiler::compile(DuplicateCsrfController::class);
+})->throws(LogicException::class, 'cannot repeat the #[Csrf] attribute');

--- a/tests/Unit/Session/ApplicationSessionTest.php
+++ b/tests/Unit/Session/ApplicationSessionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use GustavPHP\Gustav\{Application, Configuration, Mode};
+use GustavPHP\Gustav\Session\SessionOptions;
+use GustavPHP\Tests\SessionStoreFixtures\ValidApplication\Services\DiscoveredSessionStore;
+use Nyholm\Psr7\ServerRequest;
+
+it('uses a discovered session store without imperative application setup', function () {
+    DiscoveredSessionStore::$uses = 0;
+    $application = new Application(new Configuration(
+        mode: Mode::Production,
+        namespace: 'GustavPHP\\Tests\\SessionStoreFixtures\\ValidApplication',
+        session: new SessionOptions(),
+    ));
+
+    $response = $application->handle(new ServerRequest('GET', '/session-store'));
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and(json_decode((string) $response->getBody(), true))->toBe(['visits' => 1])
+        ->and(DiscoveredSessionStore::$uses)->toBeGreaterThan(0);
+});
+
+it('rejects CSRF-protected routes when sessions are disabled', function () {
+    expect(fn () => new Application(new Configuration(
+        mode: Mode::Production,
+        namespace: 'GustavPHP\\Tests\\SessionStoreFixtures\\InvalidApplication',
+    )))->toThrow(LogicException::class, 'requires session configuration');
+});

--- a/tests/Unit/Session/FileSessionStoreTest.php
+++ b/tests/Unit/Session/FileSessionStoreTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use GustavPHP\Gustav\Session\{FileSessionStore, SessionOptions, SessionRecord};
+
+function temporarySessionDirectory(): string
+{
+    return sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gustav-session-test-' . bin2hex(random_bytes(8));
+}
+
+function removeSessionDirectory(string $directory): void
+{
+    if (!is_dir($directory)) {
+        return;
+    }
+    foreach (new DirectoryIterator($directory) as $file) {
+        if ($file->isFile()) {
+            unlink($file->getPathname());
+        }
+    }
+    rmdir($directory);
+}
+
+it('creates storage lazily and persists records between store instances', function () {
+    $directory = temporarySessionDirectory();
+    $options = new SessionOptions(directory: $directory, garbageCollectionProbability: 0);
+    $id = str_repeat('a', 43);
+
+    try {
+        $store = new FileSessionStore($options);
+        expect(is_dir($directory))->toBeFalse();
+        $lease = $store->acquire($id, true);
+        expect($lease)->not->toBeNull();
+        $lease?->write(new SessionRecord(['count' => 0], ['notice' => 'saved'], time() + 60));
+        $lease?->release();
+
+        $restored = (new FileSessionStore($options))->acquire($id);
+        expect($restored?->read()?->data)->toBe(['count' => 0])
+            ->and($restored?->read()?->flash)->toBe(['notice' => 'saved']);
+        $restored?->release();
+    } finally {
+        removeSessionDirectory($directory);
+    }
+});
+
+it('does not create a file for an unrecognized client identifier', function () {
+    $directory = temporarySessionDirectory();
+    $store = new FileSessionStore(new SessionOptions(
+        directory: $directory,
+        garbageCollectionProbability: 0,
+    ));
+
+    try {
+        expect($store->acquire(str_repeat('b', 43)))->toBeNull();
+        $files = iterator_to_array(new FilesystemIterator($directory));
+        expect($files)->toBe([]);
+    } finally {
+        removeSessionDirectory($directory);
+    }
+});
+
+it('collects expired and empty records while keeping active sessions', function () {
+    $directory = temporarySessionDirectory();
+    $store = new FileSessionStore(new SessionOptions(
+        directory: $directory,
+        garbageCollectionProbability: 0,
+    ));
+    $expired = str_repeat('c', 43);
+    $empty = str_repeat('d', 43);
+    $active = str_repeat('e', 43);
+
+    try {
+        $lease = $store->acquire($expired, true);
+        $lease?->write(new SessionRecord([], [], time() - 1));
+        $lease?->release();
+        $store->acquire($empty, true)?->release();
+        $lease = $store->acquire($active, true);
+        $lease?->write(new SessionRecord(['active' => true], [], time() + 60));
+        $lease?->release();
+
+        $store->collectGarbage();
+
+        expect($store->acquire($expired))->toBeNull()
+            ->and($store->acquire($empty))->toBeNull();
+        $activeLease = $store->acquire($active);
+        expect($activeLease?->read()?->data)->toBe(['active' => true]);
+        $activeLease?->release();
+    } finally {
+        removeSessionDirectory($directory);
+    }
+});

--- a/tests/Unit/Session/SessionOptionsTest.php
+++ b/tests/Unit/Session/SessionOptionsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use GustavPHP\Gustav\Session\{SameSite, SessionOptions};
+
+it('provides secure server-side session defaults', function () {
+    $options = new SessionOptions(directory: '/tmp/sessions');
+
+    expect($options->cookieName)->toBe('gustav_session')
+        ->and($options->lifetime)->toBe(7200)
+        ->and($options->cookiePath)->toBe('/')
+        ->and($options->secure)->toBeNull()
+        ->and($options->sameSite)->toBe(SameSite::Lax)
+        ->and($options->garbageCollectionProbability)->toBe(1);
+});
+
+it('rejects unsafe cookie and storage options', function (array $arguments) {
+    expect(fn () => new SessionOptions(...$arguments))
+        ->toThrow(InvalidArgumentException::class);
+})->with([
+    'empty directory' => [['directory' => '']],
+    'invalid cookie name' => [['cookieName' => 'bad cookie']],
+    'non-positive lifetime' => [['lifetime' => 0]],
+    'relative cookie path' => [['cookiePath' => 'admin']],
+    'cookie path injection' => [['cookiePath' => "/;\r\nInjected: yes"]],
+    'domain injection' => [['cookieDomain' => "example.com\r\nInjected: yes"]],
+    'insecure SameSite none' => [['sameSite' => SameSite::None]],
+    'insecure secure prefix' => [['cookieName' => '__Secure-session']],
+    'host prefix with domain' => [[
+        'cookieName' => '__Host-session',
+        'secure' => true,
+        'cookieDomain' => 'example.com',
+    ]],
+    'invalid garbage collection chance' => [['garbageCollectionProbability' => 101]],
+]);
+
+it('accepts a correctly constrained host cookie', function () {
+    $options = new SessionOptions(
+        cookieName: '__Host-session',
+        secure: true,
+        sameSite: SameSite::Strict,
+    );
+
+    expect($options->cookiePath)->toBe('/')
+        ->and($options->cookieDomain)->toBeNull();
+});

--- a/tests/Unit/Session/SessionTest.php
+++ b/tests/Unit/Session/SessionTest.php
@@ -1,0 +1,187 @@
+<?php
+
+use GustavPHP\Gustav\Session;
+use GustavPHP\Gustav\Session\SessionOptions;
+use GustavPHP\Tests\SessionFixtures\MemorySessionStore;
+use Nyholm\Psr7\{Response, ServerRequest};
+use Psr\Http\Message\ResponseInterface;
+
+function sessionCookieId(ResponseInterface $response, string $name = 'gustav_session'): string
+{
+    $cookie = $response->getHeaderLine('Set-Cookie');
+    expect($cookie)->toContain("{$name}=");
+    preg_match('/(?:^|;\s*)' . preg_quote($name, '/') . '=([^;]*)/', $cookie, $matches);
+
+    return $matches[1] ?? '';
+}
+
+function requestWithSession(string $id, string $uri = 'http://example.test/'): ServerRequest
+{
+    return (new ServerRequest('GET', $uri))->withCookieParams(['gustav_session' => $id]);
+}
+
+it('does not create storage or a cookie until session state is used', function () {
+    $store = new MemorySessionStore();
+    $session = new Session($store, new SessionOptions(), new ServerRequest('GET', '/'));
+    $response = $session->complete(new Response());
+
+    expect($store->acquisitions)->toBe(0)
+        ->and($store->ids())->toBe([])
+        ->and($response->hasHeader('Set-Cookie'))->toBeFalse();
+});
+
+it('persists JSON-compatible values including explicit null', function () {
+    $store = new MemorySessionStore();
+    $options = new SessionOptions();
+    $first = new Session($store, $options, new ServerRequest('GET', '/'));
+    $first->put('profile', ['name' => 'Ada', 'active' => false, 'score' => 0.0]);
+    $first->put('nullable', null);
+    $id = sessionCookieId($first->complete(new Response()));
+
+    $second = new Session($store, $options, requestWithSession($id));
+
+    expect($second->get('profile'))->toBe(['name' => 'Ada', 'active' => false, 'score' => 0.0])
+        ->and($second->has('nullable'))->toBeTrue()
+        ->and($second->get('nullable', 'fallback'))->toBeNull();
+
+    $second->complete(new Response());
+});
+
+it('expires flash data after the next successful request', function () {
+    $store = new MemorySessionStore();
+    $options = new SessionOptions();
+    $first = new Session($store, $options, new ServerRequest('GET', '/'));
+    $first->flash('notice', null);
+    $id = sessionCookieId($first->complete(new Response()));
+
+    $second = new Session($store, $options, requestWithSession($id));
+    expect($second->hasFlash('notice'))->toBeTrue()
+        ->and($second->getFlash('notice', 'fallback'))->toBeNull();
+    $second->complete(new Response());
+
+    $third = new Session($store, $options, requestWithSession($id));
+    expect($third->hasFlash('notice'))->toBeFalse();
+    $third->complete(new Response());
+});
+
+it('can keep flash data for another request', function () {
+    $store = new MemorySessionStore();
+    $options = new SessionOptions();
+    $first = new Session($store, $options, new ServerRequest('GET', '/'));
+    $first->flash('notice', 'saved');
+    $id = sessionCookieId($first->complete(new Response()));
+
+    $second = new Session($store, $options, requestWithSession($id));
+    $second->keepFlash('notice');
+    $second->complete(new Response());
+
+    $third = new Session($store, $options, requestWithSession($id));
+    expect($third->pullFlash('notice'))->toBe('saved')
+        ->and($third->hasFlash('notice'))->toBeFalse();
+    $third->complete(new Response());
+});
+
+it('regenerates identifiers without losing session state', function () {
+    $store = new MemorySessionStore();
+    $options = new SessionOptions();
+    $first = new Session($store, $options, new ServerRequest('GET', '/'));
+    $first->put('user_id', 42);
+    $oldId = sessionCookieId($first->complete(new Response()));
+
+    $second = new Session($store, $options, requestWithSession($oldId));
+    $second->regenerate();
+    $newId = sessionCookieId($second->complete(new Response()));
+
+    expect($newId)->not->toBe($oldId)
+        ->and($store->acquire($oldId))->toBeNull();
+    $restored = new Session($store, $options, requestWithSession($newId));
+    expect($restored->get('user_id'))->toBe(42);
+    $restored->complete(new Response());
+});
+
+it('invalidates storage and expires the browser cookie', function () {
+    $store = new MemorySessionStore();
+    $options = new SessionOptions();
+    $first = new Session($store, $options, new ServerRequest('GET', '/'));
+    $first->put('user_id', 42);
+    $id = sessionCookieId($first->complete(new Response()));
+
+    $second = new Session($store, $options, requestWithSession($id));
+    $second->invalidate();
+    $response = $second->complete(new Response());
+
+    expect($store->acquire($id))->toBeNull()
+        ->and($response->getHeaderLine('Set-Cookie'))->toContain('gustav_session=')
+        ->toContain('Max-Age=0');
+});
+
+it('does not commit mutations when a request fails', function (int $status) {
+    $store = new MemorySessionStore();
+    $options = new SessionOptions();
+    $first = new Session($store, $options, new ServerRequest('GET', '/'));
+    $first->put('value', 'before');
+    $id = sessionCookieId($first->complete(new Response()));
+
+    $failed = new Session($store, $options, requestWithSession($id));
+    $failed->put('value', 'after');
+    if ($status === 0) {
+        $failed->abort();
+    } else {
+        $failed->complete(new Response($status));
+    }
+
+    $next = new Session($store, $options, requestWithSession($id));
+    expect($next->get('value'))->toBe('before');
+    $next->complete(new Response());
+})->with(['exception' => [0], 'server error' => [500]]);
+
+it('uses secure cookie attributes and automatically detects HTTPS', function () {
+    $store = new MemorySessionStore();
+    $session = new Session(
+        $store,
+        new SessionOptions(cookieName: 'session', lifetime: 60),
+        new ServerRequest('GET', 'https://example.test/'),
+    );
+    $session->put('key', 'value');
+    $cookie = $session->complete(new Response())->getHeaderLine('Set-Cookie');
+
+    expect($cookie)->toContain('Secure')
+        ->toContain('HttpOnly')
+        ->toContain('SameSite=Lax')
+        ->toContain('Max-Age=60');
+});
+
+it('clears malformed identifiers without touching storage', function () {
+    $store = new MemorySessionStore();
+    $session = new Session($store, new SessionOptions(), requestWithSession('not-valid'));
+    $response = $session->complete(new Response());
+
+    expect($store->acquisitions)->toBe(0)
+        ->and($response->getHeaderLine('Set-Cookie'))->toContain('Max-Age=0');
+});
+
+it('clears an unrecognized identifier when session state is read', function () {
+    $store = new MemorySessionStore();
+    $session = new Session($store, new SessionOptions(), requestWithSession(str_repeat('a', 43)));
+    expect($session->get('missing'))->toBeNull();
+    $response = $session->complete(new Response());
+
+    expect($store->acquisitions)->toBe(1)
+        ->and($response->getHeaderLine('Set-Cookie'))->toContain('Max-Age=0');
+});
+
+it('rejects invalid keys and non-JSON-compatible values', function (string $key, mixed $value) {
+    $session = new Session(
+        new MemorySessionStore(),
+        new SessionOptions(),
+        new ServerRequest('GET', '/'),
+    );
+
+    expect(fn () => $session->put($key, $value))->toThrow(InvalidArgumentException::class);
+})->with([
+    'invalid key' => ['invalid key', 'value'],
+    'object' => ['value', new stdClass()],
+    'infinite float' => ['value', INF],
+    'invalid utf8' => ['value', "\xFF"],
+    'invalid nested key' => ['value', ["\xFF" => 'invalid']],
+]);


### PR DESCRIPTION
## Summary

- add a lazy request-scoped `Session` service with persistent values, flash data, ID regeneration, and invalidation
- enable a locked file-backed store at `storage/sessions` for conventional projects
- compile class- or method-level `#[Csrf]` metadata into unsafe route definitions
- accept CSRF tokens from `_token` or `X-CSRF-Token`, removing the form field before body/DTO binding
- allow a discovered singleton `SessionStoreInterface` implementation to replace the default without `$app->...` setup
- extend the RoadRunner transport contract with a rejected request followed by valid same-worker session requests

## Design decisions

- Session IDs are opaque 256-bit base64url values; arbitrary valid-looking client IDs never create storage.
- Session values are limited to JSON-compatible scalars and arrays. Objects, resources, invalid UTF-8, and non-finite floats fail explicitly.
- The store contract returns an exclusive per-session lease. The default store holds `flock()` only after session state is opened and releases it on every success/failure path.
- Session state is not committed for exceptions or `5xx` responses. Flash data is retained when such a request fails.
- Cookies are HTTP-only and `SameSite=Lax` by default, with HTTPS-aware `Secure`, configurable lifetime/path/domain, and validated `__Secure-`/`__Host-` constraints.
- `GET`, `HEAD`, `OPTIONS`, and `TRACE` are never CSRF-gated. A protected unsafe route with sessions disabled fails application startup.
- Malformed JSON remains `400`, unsupported body media remains `415`, invalid CSRF is a typed production-safe JSON `403`, and unexpected failures remain safe `500` responses.
- The file store is the single-host default. Multi-replica deployments are expected to provide a discovered shared store with equivalent locking semantics.

## Verification

- `composer format` — passed
- `composer dump-autoload --optimize --strict-psr` — passed (4,772 classes)
- `composer test` — passed (307 tests, 874 assertions)
- `composer check` — passed
- `composer lint` — passed
- `composer audit --format=plain` — no advisories
- `composer validate --strict --no-check-publish` — valid
- `git diff --check` — passed
- `composer test:transport` — passed
  - JSON: `200`
  - malformed JSON: `400`
  - session/CSRF worker sequence: `200 → 403 → 200 → 200`
  - internal failure recovery: `500 → 200`

## Linked follow-ups

- gustav-php/starter#20
- gustav-php/gustav-php.github.io#11